### PR TITLE
Make .editorconfig symlink relative

### DIFF
--- a/cli/actions/setup.js
+++ b/cli/actions/setup.js
@@ -97,7 +97,7 @@ module.exports = (program) => {
     // Creates a symbolic link from our local
     // .editorconfig to the user's base directory.
     const createEditorconfigLink = () => {
-      const editorPath = path.join(userRootPath, 'node_modules/kyt/.editorconfig');
+      const editorPath = './node_modules/kyt/.editorconfig';
       const configPath = path.join(userRootPath, '.editorconfig');
       if (shell.ln('-s', editorPath, configPath).code === 0) {
         logger.task('Linked .editorconfig');


### PR DESCRIPTION
I hit this bug when I was spinning up `story-react-oak`. The `.editorconfig` symlink needs to be relative so that it's shareable in a repo. Having an absolute path means it won't work when another developer pulls it.
