### PR TITLE
Run Tests with Ava configuration instead of babel precompile

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,17 +10,6 @@
         "babel-plugin-transform-react-remove-prop-types",
         "babel-plugin-transform-react-constant-elements"
       ]
-    },
-    "TEST": {
-      "plugins": [
-        [
-          "babel-plugin-webpack-loaders",
-          {
-            "config": "./webpack.config.js",
-            "verbose": false
-          }
-        ]
-      ]
     }
   }
 }

--- a/cli/actions/test.js
+++ b/cli/actions/test.js
@@ -9,7 +9,7 @@ const kytConfig = require('./../../config/kyt.config');
 
 module.exports = () => {
   // Comment the following to see verbose shell ouput.
-  //shell.config.silent = true;
+  shell.config.silent = true;
 
   const userRootPath = kytConfig.userRootPath;
   const userSrc = path.join(userRootPath, 'src');
@@ -34,6 +34,7 @@ module.exports = () => {
 
   // Copy ava's configuration into the root
   shell.cp(avaPkgJsonPath, testPkgJsonPath);
+
   // Copy the webpack config into the temp directory
   shell.cp(testConfigPath, newConfigPath);
 

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -22,6 +22,7 @@ const options = {
   type: 'test',
   userRootPath,
 };
+
 const babelrc = {};
 babelrc.babelrc = false;
 babelrc.presets = [];


### PR DESCRIPTION
Someone else needs to run this on newsreader and the starter-kyts and prove that it works, esp. since I was so sure it worked the last time.

Thanks!

Fixes #62 
