### PR TITLE
Fixes public directory path problems

### DIFF
--- a/cli/actions/build.js
+++ b/cli/actions/build.js
@@ -39,6 +39,8 @@ module.exports = () => {
     // copy files
     shell.cp('-r', userPublicPath, buildPublicPath);
     logger.task('Copied /src/public to /build/public');
+  } else {
+    shell.mkdir('-p', `${buildPath}/public`);
   }
 
   // Compiles server code using the prod.server config

--- a/config/webpack.dev.server.js
+++ b/config/webpack.dev.server.js
@@ -17,6 +17,11 @@ const cssStyleLoaders = [
 module.exports = (options) => ({
   target: 'node',
 
+  node: {
+    __dirname: false,
+    __filename: false,
+  },
+
   externals: nodeExternals(),
 
   entry: {

--- a/config/webpack.prod.client.js
+++ b/config/webpack.prod.client.js
@@ -25,7 +25,7 @@ module.exports = (options) => ({
   },
 
   output: {
-    path: path.join(options.publicDir, 'assets'),
+    path: path.join(options.publicDirPath, 'assets'),
     filename: '[name]-[hash].js',
     chunkFilename: '[name]-[chunkhash].js',
     publicPath: options.publicPath,

--- a/config/webpack.prod.server.js
+++ b/config/webpack.prod.server.js
@@ -16,6 +16,11 @@ const cssStyleLoaders = [
 module.exports = (options) => ({
   target: 'node',
 
+  node: {
+    __dirname: false,
+    __filename: false,
+  },
+
   externals: nodeExternals(),
 
   entry: {

--- a/utils/buildConfigs.js
+++ b/utils/buildConfigs.js
@@ -23,14 +23,14 @@ module.exports = (environment = 'development') => {
   let clientConfig = devClientConfig;
   let serverConfig = devServerConfig;
 
-  const clientOptions = {
+  let clientOptions = {
     type: 'client',
     serverPort,
     clientPort,
     environment,
     buildPath,
     publicPath: `http://localhost:${clientPort}/assets/`,
-    publicDir: path.join(userRootPath, 'src/public'),
+    publicDir: path.join(userRootPath, 'build/client'),
     clientAssetsFile: 'publicAssets.json',
     userRootPath,
     reactHotLoader,
@@ -40,9 +40,15 @@ module.exports = (environment = 'development') => {
   if (environment === 'production') {
     clientConfig = prodClientConfig;
     serverConfig = prodServerConfig;
-    clientOptions.clientPort = undefined;
-    clientOptions.publicPath = kytConfig.productionPublicPath;
-    clientOptions.publicDir = path.join(buildPath, 'public');
+    clientOptions = merge(clientOptions, {
+      clientPort: undefined,
+      publicPath: kytConfig.productionPublicPath,
+      // In production, we use the relative path
+      // from build/client/*.js or build/server/*.js.
+      publicDir: '../public',
+      // Absolute path to the public directory.
+      publicDirPath: path.join(buildPath, 'public'),
+    });
   }
 
   const serverOptions = merge(clientOptions, {


### PR DESCRIPTION
- fixes a pathing problem and adds the public directory path to the environment as a relative path from the `build/*` directories
- fixes `__dirname` when resolved from the build directory
- the `public/assets` were building to the `src` directory in user projects

In user projects, when referencing the static public directory, you will now need to use the following:

`app.use(express.static(path.join(__dirname, process.env.PUBLIC_DIR)));`

fixes #68 
