### PR TITLE
Removes webpack dev server when `reactHotLoader:false`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
   "plugins": ["babel-plugin-transform-runtime"],
   "env": {
     "development": {
-      "plugins": ["react-hot-loader/babel"]
+      "plugins": []
     },
     "production": {
       "plugins": [

--- a/cli/actions/dev.js
+++ b/cli/actions/dev.js
@@ -13,7 +13,6 @@ const kytConfig = require('./../../config/kyt.config');
 const ifPortIsFreeDo = require('../../utils/ifPortIsFreeDo');
 const buildConfigs = require('../../utils/buildConfigs');
 const webpackCompiler = require('../../utils/webpackCompiler');
-const WebpackDevServer = require('webpack-dev-server');
 
 module.exports = () => {
   logger.start('Starting development build...');
@@ -39,27 +38,13 @@ module.exports = () => {
   let serverCompiler;
   let server = null;
 
-  const getHotClient = (options) => {
+  const startClient = () => {
+    const devOptions = clientCompiler.options.devServer;
     const app = express();
-    const webpackDevMiddleware = devMiddleware(clientCompiler, options);
+    const webpackDevMiddleware = devMiddleware(clientCompiler, devOptions);
 
     app.use(webpackDevMiddleware);
     app.use(hotMiddleware(clientCompiler));
-
-    return app;
-  };
-
-  const getDevServer = (options) => new WebpackDevServer(clientCompiler, options);
-
-  const startClient = () => {
-    const devOptions = {
-      publicPath: clientCompiler.options.output.publicPath,
-      headers: { 'Access-Control-Allow-Origin': '*' },
-      noInfo: true,
-      quiet: true,
-    };
-
-    const app = reactHotLoader ? getHotClient(devOptions) : getDevServer(devOptions);
     app.listen(clientPort);
   };
 
@@ -121,6 +106,9 @@ module.exports = () => {
     } else startHotServer();
   });
 
-  // Start client hot server
+  // Starting point...
+  // By starting the client, the middleware will
+  // compile the client configuration and trigger
+  // the `clientCompiler` callback.
   ifPortIsFreeDo(clientPort, startClient);
 };

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -1,97 +1,101 @@
 
-// Base webpack config
+// All webpack configurations are merged into this
+// base. See more about (smart) merging here:
+// https://github.com/survivejs/webpack-merge
 
 const path = require('path');
 const webpack = require('webpack');
 const fs = require('fs');
 
-// Create the babelrc query for the babel loader.
-const babelrc = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../.babelrc'), 'utf8'));
 // Uses require.resolve to add the full paths to all of the plugins
 // and presets, making sure that we handle the new array syntax.
 const resolvePluginsPresets = (babelGroup) => {
-  babelGroup.plugins = (babelGroup.plugins || []).map((plugin) => {
-    if (typeof plugin === 'object') {
-      plugin[0] = require.resolve(plugin[0]);
-      return plugin;
+  const resolve = (dep) => {
+    if (typeof dep === 'object') {
+      dep[0] = require.resolve(dep[0]);
+      return dep;
     }
-    return require.resolve(plugin);
-  });
-  babelGroup.presets = (babelGroup.presets || []).map((preset) => {
-    if (typeof preset === 'object') {
-      preset[0] = require.resolve(preset[0]);
-      return preset;
-    }
-    return require.resolve(preset);
-  });
+    return require.resolve(dep);
+  };
+  babelGroup.plugins = (babelGroup.plugins || []).map(resolve);
+  babelGroup.presets = (babelGroup.presets || []).map(resolve);
 };
-babelrc.babelrc = false;
-resolvePluginsPresets(babelrc);
-Object.keys(babelrc.env || {}).forEach((env) => resolvePluginsPresets(babelrc.env[env]));
 
-module.exports = (options) => ({
-  node: {
-    __dirname: true,
-    __filename: true,
-  },
+module.exports = (options) => {
+  // Create the babelrc query for the babel loader.
+  const babelrc = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../.babelrc'), 'utf8'));
+  babelrc.babelrc = false;
+  resolvePluginsPresets(babelrc);
+  if (options.reactHotLoader) {
+    babelrc.env.development.plugins.push('react-hot-loader/babel');
+  }
+  Object.keys(babelrc.env || {}).forEach((env) => resolvePluginsPresets(babelrc.env[env]));
 
-  devtool: 'source-map',
+  return {
 
-  resolve: {
-    extensions: ['.js', '.json'],
-    modules: [`${options.userRootPath}/node_modules`, path.resolve(__dirname, '../node_modules')],
-  },
+    node: {
+      __dirname: true,
+      __filename: true,
+    },
 
-  resolveLoader: {
-    modules: [`${options.userRootPath}/node_modules`, path.resolve(__dirname, '../node_modules')],
-  },
+    devtool: 'source-map',
 
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify(options.environment),
-        SERVER_PORT: JSON.stringify(options.serverPort),
-        CLIENT_PORT: JSON.stringify(options.clientPort || ''),
-        PUBLIC_PATH: JSON.stringify(options.publicPath),
-        PUBLIC_DIR: JSON.stringify(options.publicDir),
-        CLIENT_BUILD_PATH: JSON.stringify(path.join(options.publicDir, 'assets')),
-        SERVER_BUILD_PATH: JSON.stringify(path.join(options.buildPath, 'server')),
-        ASSETS_MANIFEST: JSON.stringify(path.join(options.buildPath, options.clientAssetsFile)),
-      },
-    }),
-  ],
+    resolve: {
+      extensions: ['.js', '.json'],
+      modules: [`${options.userRootPath}/node_modules`, path.resolve(__dirname, '../node_modules')],
+    },
 
-  postcss: [
-    // Users should add their own postcss plugins for the css
-    // and sass loaders through the `modifyWebpackConfig` callback.
-  ],
+    resolveLoader: {
+      modules: [`${options.userRootPath}/node_modules`, path.resolve(__dirname, '../node_modules')],
+    },
 
-  module: {
-    loaders: [
-      {
-        test: /\.html$/,
-        loader: 'file?name=[name].[ext]',
-      },
-      {
-        test: /\.(jpg|jpeg|png|gif|eot|svg|ttf|woff|woff2)$/,
-        loader: 'url-loader',
-        query: {
-          limit: 20000,
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify(options.environment),
+          SERVER_PORT: JSON.stringify(options.serverPort),
+          CLIENT_PORT: JSON.stringify(options.clientPort || ''),
+          PUBLIC_PATH: JSON.stringify(options.publicPath),
+          PUBLIC_DIR: JSON.stringify(options.publicDir),
+          CLIENT_BUILD_PATH: JSON.stringify(path.join(options.publicDir, 'assets')),
+          SERVER_BUILD_PATH: JSON.stringify(path.join(options.buildPath, 'server')),
+          ASSETS_MANIFEST: JSON.stringify(path.join(options.buildPath, options.clientAssetsFile)),
         },
-      },
-      {
-        test: /\.json$/,
-        loader: 'json-loader',
-      },
-      {
-        test: /\.(js|jsx)$/,
-        loader: 'babel-loader',
-        exclude: [
-          /node_modules/,
-          options.buildPath,
-        ],
-        query: babelrc,
-      },
+      }),
     ],
-  },
-});
+
+    postcss: [
+      // Users should add their own postcss plugins for the css
+      // and sass loaders through the `modifyWebpackConfig` callback.
+    ],
+
+    module: {
+      loaders: [
+        {
+          test: /\.html$/,
+          loader: 'file?name=[name].[ext]',
+        },
+        {
+          test: /\.(jpg|jpeg|png|gif|eot|svg|ttf|woff|woff2)$/,
+          loader: 'url-loader',
+          query: {
+            limit: 20000,
+          },
+        },
+        {
+          test: /\.json$/,
+          loader: 'json-loader',
+        },
+        {
+          test: /\.(js|jsx)$/,
+          loader: 'babel-loader',
+          exclude: [
+            /node_modules/,
+            options.buildPath,
+          ],
+          query: babelrc,
+        },
+      ],
+    },
+  };
+};

--- a/config/webpack.dev.client.js
+++ b/config/webpack.dev.client.js
@@ -17,26 +17,11 @@ const cssStyleLoaders = [
 
 module.exports = (options) => {
   const main = [
-    path.join(options.userRootPath, 'src/client/index.js'),
-  ];
-  const plugins = [
-    new webpack.NoErrorsPlugin(),
-    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
-    new AssetsPlugin({
-      filename: options.clientAssetsFile,
-      path: options.buildPath,
-    }),
+    `webpack-hot-middleware/client?reload=true&path=http://localhost:${options.clientPort}/__webpack_hmr`,
+    path.join(options.userRootPath, 'src/client/index.js')
   ];
 
-  if (options.reactHotLoader) {
-    main.unshift(
-      'react-hot-loader/patch',
-      `webpack-hot-middleware/client?reload=true&path=http://localhost:${options.clientPort}/__webpack_hmr`
-    );
-    plugins.push(new webpack.HotModuleReplacementPlugin());
-  } else {
-    main.unshift(`webpack-dev-server/client?http://localhost:${options.clientPort}`);
-  }
+  if (options.reactHotLoader) main.unshift('react-hot-loader/patch');
 
   return {
     target: 'web',
@@ -53,6 +38,13 @@ module.exports = (options) => {
       libraryTarget: 'var',
     },
 
+    devServer: {
+      publicPath: options.publicPath,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      noInfo: true,
+      quiet: true,
+    },
+
     module: {
       loaders: [
         {
@@ -66,6 +58,17 @@ module.exports = (options) => {
       ],
     },
 
-    plugins,
+    plugins: [
+      new webpack.NoErrorsPlugin(),
+
+      new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+
+      new AssetsPlugin({
+        filename: options.clientAssetsFile,
+        path: options.buildPath,
+      }),
+
+      new webpack.HotModuleReplacementPlugin(),
+    ],
   };
 };


### PR DESCRIPTION
Removes the WebpackDevServer mode when the `reactHotLoader` setting is false. In its place, we keep Webpack HMR but remove the React specific entry point and babelrc plugin. `reactHotLoader:true` will add the React specific hot module parts.

I also, added the `devServer`settings to the webpack configuration in case users need to change it. In a follow-up pull request, we should create settings for the server hosts. We shouldn't hardcode http and localhost.
