### PR TITLE
removes jsx support

### DIFF
--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -86,7 +86,7 @@ module.exports = (options) => {
           loader: 'json-loader',
         },
         {
-          test: /\.(js|jsx)$/,
+          test: /\.js$/,
           loader: 'babel-loader',
           exclude: [
             /node_modules/,


### PR DESCRIPTION
We talked about this a while ago and I think we forgot to actually do it. 
We should write an extension for vi and wf-components. Maybe a recipe too in case other projects need it. 
