### PR TITLE
Removes uglifyjs warnings during build

### DIFF
--- a/config/webpack.prod.client.js
+++ b/config/webpack.prod.client.js
@@ -62,6 +62,7 @@ module.exports = (options) => ({
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         screw_ie8: true,
+        warnings: false,
       },
       output: {
         comments: false,


### PR DESCRIPTION
I know we read somewhere that uglifyjs doesn't need `warnings:false`, but I'm seeing hundreds of lines of warnings during `build`. I added it back.
