### PR TITLE
Update package.json License

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/nytimes/kyt.git"
   },
   "author": "NYTimes",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/nytimes/kyt/issues"
   },


### PR DESCRIPTION
Valid [SPDX License](https://spdx.org/licenses/) is `Apache-2.0`
