### PR TITLE
Updates mobile readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # kyt
 
-Every sizable JavaScript web app needs a common foundation: a setup to build, run, test and lint your code. Typical project setup includes copying configuration boilerplate, managing and updating it over the lifetime of the project. **kyt is a toolkit that encapsulates and manages the configuration for web apps.**
+Every sizable JavaScript web app needs a common foundation: a setup to build, run, test and lint your code.  
+kyt is a toolkit that encapsulates and manages the configuration for web apps.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # kyt
 
-Every sizable JavaScript web app needs a common foundation: a setup to build, run, test and lint your code.  
+Every sizable JavaScript web app needs a common foundation: a setup to build, run, test and lint your code.
+
 kyt is a toolkit that encapsulates and manages the configuration for web apps.
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # kyt
 
 Every sizable JavaScript web app needs a common foundation: a setup to build, run, test and lint your code.
-
 kyt is a toolkit that encapsulates and manages the configuration for web apps.
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 # kyt
 
-Every sizable JavaScript web app needs a common foundation: a setup to build, run, test and lint your code. Typical project setup includes copying configuration boilerplate, managing and updating it over the lifetime of the project.
-
-kyt is a toolkit that encapsulates and manages the configuration for web apps.
+Every sizable JavaScript web app needs a common foundation: a setup to build, run, test and lint your code. Typical project setup includes copying configuration boilerplate, managing and updating it over the lifetime of the project. **kyt is a toolkit that encapsulates and manages the configuration for web apps.**
 
 ## Quick Start
 


### PR DESCRIPTION
Tiny Change.
Previously only the problem statements were showing up on the summarized github README on mobile. Now the sentence about what kyt is will also be included.

![2016-09-13 1](https://cloud.githubusercontent.com/assets/4968097/18472669/c39ecda6-7986-11e6-868f-e808e0476d17.png)
![2016-09-13](https://cloud.githubusercontent.com/assets/4968097/18472672/c56611b2-7986-11e6-92ef-9950ef34b6b6.png)
