### PR TITLE
docs: add Travis build status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/NYTimes/kyt.svg?branch=master)](https://travis-ci.org/NYTimes/kyt)
+
 <p align="center"><img src="/images/kyt-logo-large.png"></p>
 
 # kyt


### PR DESCRIPTION
Adds a badge showing the status of the most recent Master branch build on Travis.