### PR TITLE
chore: fix for deprecated eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,8 @@
       "prefer-reflect": 2,
       "no-warning-comments": [1, { "terms": ["todo", "fixme"], "location": "start" }],
       "react/sort-comp": 0,
-      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+      "react/require-extension": "off",
+      "import/extensions": [1, { "js": "never", "jsx": "never" }],
       "import/no-unresolved": [2, { "ignore": ["ava"] }],
       "import/no-extraneous-dependencies": [0],
       "no-param-reassign": 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,7 @@
       "no-warning-comments": [1, { "terms": ["todo", "fixme"], "location": "start" }],
       "react/sort-comp": 0,
       "react/require-extension": "off",
-      "import/extensions": [1, { "js": "never", "jsx": "never" }],
+      "import/extensions": [1, { "js": "never" }],
       "import/no-unresolved": [2, { "ignore": ["ava"] }],
       "import/no-extraneous-dependencies": [0],
       "no-param-reassign": 0


### PR DESCRIPTION
Closes #164 

Replaces the deprecated [`react/require-extension`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-extension.md) in `.eslintrc` with the recommended [`import/extensions`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md) rule from `eslint-plugin-import`.

Additionally, applies [this fix](https://github.com/airbnb/javascript/issues/978#issuecomment-244611697) to prevent the following (now incorrect) console output: `The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.`  

See [these lines](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js#L109-L110) in `eslint-config-airbnb` for the relevant TODO.



