### PR TITLE
fixes bug where dev server doesnt close after webpack compile error

### DIFF
--- a/cli/actions/dev.js
+++ b/cli/actions/dev.js
@@ -18,6 +18,11 @@ const { buildPath, serverSrcPath } = require('../../utils/paths')();
 module.exports = (config) => {
   logger.start('Starting development build...');
 
+  // Kill the server on exit.
+  process.on('SIGINT', () => {
+    process.exit();
+  });
+
   let clientCompiler;
   let serverCompiler;
   const { clientConfig, serverConfig } = buildConfigs(config);

--- a/cli/actions/dev.js
+++ b/cli/actions/dev.js
@@ -19,9 +19,7 @@ module.exports = (config) => {
   logger.start('Starting development build...');
 
   // Kill the server on exit.
-  process.on('SIGINT', () => {
-    process.exit();
-  });
+  process.on('SIGINT', process.exit);
 
   let clientCompiler;
   let serverCompiler;


### PR DESCRIPTION
Fixes #51 

The dev server wasn't closing when exiting dev after a Webpack compile error. Now the server exits cleanly.