### PR TITLE
Use KYT for globals instead of process.env

### DIFF
--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -28,8 +28,9 @@ module.exports = options => ({
 
   plugins: [
     new webpack.DefinePlugin({
+      // Hardcode NODE_ENV at build time inorder for libraries like React to get build optimized
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || options.environment),
       'KYT': {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV || options.environment),
         SERVER_PORT: JSON.stringify((options.serverURL && options.serverURL.port) || ''),
         CLIENT_PORT: JSON.stringify((options.clientURL && options.clientURL.port) || ''),
         PUBLIC_PATH: JSON.stringify(options.publicPath || ''),

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -28,7 +28,7 @@ module.exports = options => ({
 
   plugins: [
     new webpack.DefinePlugin({
-      // Hardcode NODE_ENV at build time inorder for libraries like React to get build optimized
+      // Hardcode NODE_ENV at build time so libraries like React get optimized
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || options.environment),
       'KYT': {
         SERVER_PORT: JSON.stringify((options.serverURL && options.serverURL.port) || ''),

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -28,7 +28,7 @@ module.exports = options => ({
 
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': {
+      'KYT': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV || options.environment),
         SERVER_PORT: JSON.stringify((options.serverURL && options.serverURL.port) || ''),
         CLIENT_PORT: JSON.stringify((options.clientURL && options.clientURL.port) || ''),

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -30,7 +30,7 @@ module.exports = options => ({
     new webpack.DefinePlugin({
       // Hardcode NODE_ENV at build time so libraries like React get optimized
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || options.environment),
-      'KYT': {
+      KYT: {
         SERVER_PORT: JSON.stringify((options.serverURL && options.serverURL.port) || ''),
         CLIENT_PORT: JSON.stringify((options.clientURL && options.clientURL.port) || ''),
         PUBLIC_PATH: JSON.stringify(options.publicPath || ''),

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -28,14 +28,13 @@ All `.js` files in `/src` are transpiled with Babel.
 
 ## Environment Variables
 
-kyt sets several environment variables with useful information about the app environment.
+kyt sets several global variables with useful information about the app environment.
 
-* `NODE_ENV` Node environment currently running (eg. production)
-* `SERVER_PORT` Port your node server should listen on.
-* `CLIENT_PORT` Port the client assets server is listening on.
-* `PUBLIC_PATH` Full path for static assets server
-* `PUBLIC_DIR` Relative path to the public directory
-* `ASSETS_MANIFEST` Object with build assets paths
+* `KYT.SERVER_PORT` Port your node server should listen on.
+* `KYT.CLIENT_PORT` Port the client assets server is listening on.
+* `KYT.PUBLIC_PATH` Full path for static assets server
+* `KYT.PUBLIC_DIR` Relative path to the public directory
+* `KYT.ASSETS_MANIFEST` Object with build assets paths
 
 For examples of how to use these environment variables, checkout out the simple React [starter-kyt](https://github.com/nytimes/kyt-starter)
 


### PR DESCRIPTION
Currently `kyt` is replacing `process.env` with it's own global constants. This is breaking node apps that rely on environment variables for configuration. 

This PR is introducing `KYT` as a namespace for "compile time constants" that are defined by `kyt` (SERVER_PORT, CLIENT_PORT, PUBLIC_PATH, PUBLIC_DIR, ASSETS_MANIFEST).

It is a breaking update. Any app that is currently using for example `process.env.ASSETS_MANIFEST`, need to use `KYT.ASSETS_MANIFEST` instead.