### PR TITLE
fixes pointer to stylelintrc base file name

### DIFF
--- a/cli/actions/lintStyle.js
+++ b/cli/actions/lintStyle.js
@@ -15,7 +15,7 @@ module.exports = () => {
   const stylelintrc = glob.sync(`${userRootPath}/.stylelintrc.json`);
   const configFile = stylelintrc.length
       ? stylelintrc[0]
-      : path.join(__dirname, '../../config/.stylelintrc.json');
+      : path.join(__dirname, '../../config/.stylelintrc.base.json');
 
   logger.info(`Using Stylelint file: ${configFile}`);
 


### PR DESCRIPTION
This fixes a bug where kyt's internal base stylelintrc should be used if a user .stylelintrc.json file isn't found. The filename of the base linterrc is wrong.