### PR TITLE
WIP Updates webpack and other outdated dependencies

### DIFF
--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -39,12 +39,17 @@ module.exports = options => ({
             JSON.stringify(path.join(buildPath || '', options.clientAssetsFile || '')),
       },
     }),
+
+    new webpack.LoaderOptionsPlugin({
+      options: {
+        postcss: [autoprefixer({ browsers: ['last 2 versions'] })],
+        context: '/',
+      },
+    }),
   ],
 
-  postcss: [autoprefixer({ browsers: ['last 2 versions'] })],
-
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.html$/,
         loader: 'file?name=[name].[ext]',
@@ -52,7 +57,7 @@ module.exports = options => ({
       {
         test: /\.(jpg|jpeg|png|gif|eot|svg|ttf|woff|woff2)$/,
         loader: 'url-loader',
-        query: {
+        options: {
           limit: 20000,
         },
       },
@@ -67,7 +72,7 @@ module.exports = options => ({
           /node_modules/,
           buildPath,
         ],
-        query: babel(options),
+        options: babel(options),
       },
     ],
   },

--- a/config/webpack.dev.client.js
+++ b/config/webpack.dev.client.js
@@ -10,7 +10,7 @@ const cssStyleLoaders = [
   'style',
   {
     loader: 'css',
-    query: { modules: true, sourceMap: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
+    options: { modules: true, sourceMap: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
   },
   'postcss',
 ];
@@ -46,14 +46,14 @@ module.exports = (options) => {
     },
 
     module: {
-      loaders: [
+      rules: [
         {
           test: /\.css$/,
-          loaders: cssStyleLoaders,
+          use: cssStyleLoaders,
         },
         {
           test: /\.scss$/,
-          loaders: clone(cssStyleLoaders).concat('sass'),
+          use: clone(cssStyleLoaders).concat('sass'),
         },
       ],
     },

--- a/config/webpack.dev.server.js
+++ b/config/webpack.dev.server.js
@@ -9,7 +9,7 @@ const { serverSrcPath, serverBuildPath } = require('../utils/paths')();
 const cssStyleLoaders = [
   {
     loader: 'css-loader/locals',
-    query: { modules: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
+    options: { modules: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
   },
   'postcss',
 ];
@@ -37,14 +37,14 @@ module.exports = options => ({
   },
 
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.css$/,
-        loaders: cssStyleLoaders,
+        use: cssStyleLoaders,
       },
       {
         test: /\.scss$/,
-        loaders: clone(cssStyleLoaders).concat('sass'),
+        use: clone(cssStyleLoaders).concat('sass'),
       },
     ],
 

--- a/config/webpack.prod.client.js
+++ b/config/webpack.prod.client.js
@@ -4,16 +4,9 @@
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const AssetsPlugin = require('assets-webpack-plugin');
-const clone = require('ramda').clone;
 const { clientSrcPath, assetsBuildPath, buildPath } = require('../utils/paths')();
 
-const cssStyleLoaders = [
-  {
-    loader: 'css',
-    query: { modules: true, sourceMap: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
-  },
-  'postcss',
-];
+const cssLoader = 'css?modules&sourceMap&localIdentName=[name]-[local]--[hash:base64:5]!postcss';
 
 module.exports = options => ({
   target: 'web',
@@ -33,26 +26,29 @@ module.exports = options => ({
   },
 
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract({
-          notExtractLoader: 'style',
-          loader: cssStyleLoaders,
+          fallbackLoader: 'style',
+          loader: cssLoader,
         }),
       },
       {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract({
-          notExtractLoader: 'style',
-          loader: clone(cssStyleLoaders).concat('sass'),
+          fallbackLoader: 'style',
+          loader: `${cssLoader}!sass`,
         }),
       },
     ],
   },
 
   plugins: [
-    new ExtractTextPlugin({ filename: '[name]-[chunkhash].css', allChunks: true }),
+    new ExtractTextPlugin({
+      filename: '[name]-[chunkhash].css',
+      allChunks: true,
+    }),
 
     new webpack.LoaderOptionsPlugin({
       minimize: true,

--- a/config/webpack.prod.server.js
+++ b/config/webpack.prod.server.js
@@ -8,7 +8,7 @@ const { serverSrcPath, serverBuildPath } = require('../utils/paths')();
 const cssStyleLoaders = [
   {
     loader: 'css-loader/locals',
-    query: { modules: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
+    options: { modules: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
   },
   'postcss',
 ];
@@ -36,14 +36,14 @@ module.exports = options => ({
   },
 
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.css$/,
-        loaders: cssStyleLoaders,
+        use: cssStyleLoaders,
       },
       {
         test: /\.scss$/,
-        loaders: clone(cssStyleLoaders).concat('sass'),
+        use: clone(cssStyleLoaders).concat('sass'),
       },
     ],
   },

--- a/config/webpack.proto.js
+++ b/config/webpack.proto.js
@@ -36,14 +36,14 @@ module.exports = (options) => {
     },
 
     module: {
-      loaders: [
+      rules: [
         {
           test: /\.css$/,
-          loaders: cssStyleLoaders,
+          use: cssStyleLoaders,
         },
         {
           test: /\.scss$/,
-          loaders: clone(cssStyleLoaders).concat('sass'),
+          use: clone(cssStyleLoaders).concat('sass'),
         },
       ],
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "assets-webpack-plugin": "3.4.0",
     "autoprefixer": "6.5.0",
     "babel-cli": "6.16.0",
-    "babel-core": "6.16.0",
+    "babel-core": "6.17.0",
     "babel-jest": "15.0.0",
     "babel-loader": "6.2.5",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
@@ -37,7 +37,6 @@
     "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-latest": "6.16.0",
     "babel-preset-react": "6.16.0",
-    "babel-preset-stage-3": "6.16.0",
     "chokidar": "1.6.0",
     "commander": "2.9.0",
     "css-loader": "0.25.0",
@@ -74,11 +73,11 @@
     "temp": "0.8.3",
     "url-loader": "0.5.7",
     "webpack": "2.1.0-beta.25",
-    "webpack-dev-middleware": "1.8.3",
+    "webpack-dev-middleware": "1.8.4",
     "webpack-dev-server": "2.1.0-beta.6",
-    "webpack-hot-middleware": "2.12.2",
+    "webpack-hot-middleware": "2.13.0",
     "webpack-merge": "0.14.1",
-    "webpack-node-externals": "1.4.3"
+    "webpack-node-externals": "1.5.4"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-jsx-a11y": "2.2.2",
     "eslint-plugin-react": "6.3.0",
     "express": "4.14.0",
-    "extract-text-webpack-plugin": "2.0.0-beta.3",
+    "extract-text-webpack-plugin": "2.0.0-beta.4",
     "file-loader": "0.9.0",
     "filesize": "3.3.0",
     "glob": "7.1.0",
@@ -73,12 +73,12 @@
     "stylelint-config-standard": "13.0.2",
     "temp": "0.8.3",
     "url-loader": "0.5.7",
-    "webpack": "2.1.0-beta.22",
-    "webpack-dev-middleware": "1.6.1",
-    "webpack-dev-server": "2.1.0-beta.0",
+    "webpack": "2.1.0-beta.25",
+    "webpack-dev-middleware": "1.8.3",
+    "webpack-dev-server": "2.1.0-beta.6",
     "webpack-hot-middleware": "2.12.2",
-    "webpack-merge": "0.14.0",
-    "webpack-node-externals": "1.3.3"
+    "webpack-merge": "0.14.1",
+    "webpack-node-externals": "1.4.3"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/utils/jest/preprocessor.js
+++ b/utils/jest/preprocessor.js
@@ -8,7 +8,7 @@ const { clientConfig } = buildConfigs(config);
 
 // Merge userland babel config with our babel config
 // This should go away after https://github.com/NYTimes/kyt/issues/134
-const clientBabelConfig = clientConfig.module.loaders
+const clientBabelConfig = clientConfig.module.rules
   .find(loader => loader.loader === 'babel-loader')
   .query;
 


### PR DESCRIPTION
Updates webpack to beta.25 and all of our other outdated dependencies. I did get to test the validation, mentioned in #168, and found that errors do go to the console. I did not get to play around with the multi configs option. There's not a lot of information out there, and from what I've seen it looks like it's for the command line (?).

I did a lot of testing but I could use another eye/tester on it. We should probably resurrect the e2e tests, sooner than later.

fixes #168 