### PR TITLE
Adds newlines to log statements

### DIFF
--- a/cli/__tests__/logger.test.js
+++ b/cli/__tests__/logger.test.js
@@ -26,7 +26,8 @@ describe('logger', () => {
     it(`logger.${method}: simple usage`, () => {
       logger[method]('here is some text');
       if (newlineMethods.indexOf(method) > -1) {
-        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`],[]]);
+        expect(global.console.log.mock.calls)
+          .toEqual([[`${expectedPrefix}here is some text`], []]);
       } else {
         expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
       }
@@ -39,7 +40,8 @@ describe('logger', () => {
       logger[method]('here is some text', { description: 'and a second argument' });
       expect(global.console.dir.mock.calls.length).toBe(0);
       if (newlineMethods.indexOf(method) > -1) {
-        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`],[]]);
+        expect(global.console.log.mock.calls)
+          .toEqual([[`${expectedPrefix}here is some text`], []]);
       } else {
         expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
       }
@@ -52,7 +54,7 @@ describe('logger', () => {
       expect(global.console.dir.mock.calls.length).toBe(0);
       if (newlineMethods.indexOf(method) > -1) {
         expect(global.console.log.mock.calls).toEqual(
-          [[`${expectedPrefix}here is some text\nand a second string argument`],[]]
+          [[`${expectedPrefix}here is some text\nand a second string argument`], []]
         );
       } else {
         expect(global.console.log.mock.calls).toEqual(
@@ -67,7 +69,8 @@ describe('logger', () => {
       const objectToLog = { description: 'and some object' };
       logger[method]('here is some text', objectToLog);
       if (newlineMethods.indexOf(method) > -1) {
-        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`],[]]);
+        expect(global.console.log.mock.calls)
+          .toEqual([[`${expectedPrefix}here is some text`], []]);
       } else {
         expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
       }

--- a/cli/__tests__/logger.test.js
+++ b/cli/__tests__/logger.test.js
@@ -9,21 +9,27 @@ describe('logger', () => {
   const oneArgMethods = [
     { method: 'log', expectedPrefix: '' },
     { method: 'task', expectedPrefix: '👍  ' },
-    { method: 'start', expectedPrefix: '🔥  ' },
-    { method: 'end', expectedPrefix: '✅  ' },
+    { method: 'start', expectedPrefix: '\n🔥  ' },
+    { method: 'end', expectedPrefix: '\n✅  ' },
     { method: 'info', expectedPrefix: 'ℹ️  ' },
   ];
 
   const twoArgMethods = [
     { method: 'warn', expectedPrefix: '🙀  ' },
-    { method: 'error', expectedPrefix: '❌  ' },
+    { method: 'error', expectedPrefix: '\n❌  ' },
     { method: 'debug', expectedPrefix: '🐞  ' },
   ];
+
+  const newlineMethods = ['start', 'end', 'error'];
 
   [...oneArgMethods, ...twoArgMethods].forEach(({ method, expectedPrefix }) => {
     it(`logger.${method}: simple usage`, () => {
       logger[method]('here is some text');
-      expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
+      if (newlineMethods.indexOf(method) > -1) {
+        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`],[]]);
+      } else {
+        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
+      }
       expect(global.console.dir.mock.calls.length).toBe(0);
     });
   });
@@ -32,7 +38,11 @@ describe('logger', () => {
     it(`logger.${method}: can only take one arg`, () => {
       logger[method]('here is some text', { description: 'and a second argument' });
       expect(global.console.dir.mock.calls.length).toBe(0);
-      expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
+      if (newlineMethods.indexOf(method) > -1) {
+        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`],[]]);
+      } else {
+        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
+      }
     });
   });
 
@@ -40,9 +50,15 @@ describe('logger', () => {
     it(`logger.${method}: string as second argument`, () => {
       logger[method]('here is some text', 'and a second string argument');
       expect(global.console.dir.mock.calls.length).toBe(0);
-      expect(global.console.log.mock.calls).toEqual(
-        [[`${expectedPrefix}here is some text\nand a second string argument`]]
-      );
+      if (newlineMethods.indexOf(method) > -1) {
+        expect(global.console.log.mock.calls).toEqual(
+          [[`${expectedPrefix}here is some text\nand a second string argument`],[]]
+        );
+      } else {
+        expect(global.console.log.mock.calls).toEqual(
+          [[`${expectedPrefix}here is some text\nand a second string argument`]]
+        );
+      }
     });
   });
 
@@ -50,7 +66,11 @@ describe('logger', () => {
     it(`logger.${method}: object as second argument`, () => {
       const objectToLog = { description: 'and some object' };
       logger[method]('here is some text', objectToLog);
-      expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
+      if (newlineMethods.indexOf(method) > -1) {
+        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`],[]]);
+      } else {
+        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
+      }
       expect(global.console.dir.mock.calls.length).toBe(1);
       expect(global.console.dir.mock.calls[0].length).toBe(2);
       expect(global.console.dir.mock.calls[0][0]).toBe(objectToLog);

--- a/cli/__tests__/logger.test.js
+++ b/cli/__tests__/logger.test.js
@@ -24,56 +24,42 @@ describe('logger', () => {
 
   [...oneArgMethods, ...twoArgMethods].forEach(({ method, expectedPrefix }) => {
     it(`logger.${method}: simple usage`, () => {
+      const nLogCalls = newlineMethods.includes(method) ? 2 : 1;
       logger[method]('here is some text');
-      if (newlineMethods.indexOf(method) > -1) {
-        expect(global.console.log.mock.calls)
-          .toEqual([[`${expectedPrefix}here is some text`], []]);
-      } else {
-        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
-      }
+      expect(global.console.log).toBeCalledWith(`${expectedPrefix}here is some text`);
+      expect(global.console.log.mock.calls.length).toEqual(nLogCalls);
       expect(global.console.dir.mock.calls.length).toBe(0);
     });
   });
 
   oneArgMethods.forEach(({ method, expectedPrefix }) => {
     it(`logger.${method}: can only take one arg`, () => {
+      const nLogCalls = newlineMethods.includes(method) ? 2 : 1;
       logger[method]('here is some text', { description: 'and a second argument' });
+      expect(global.console.log).toBeCalledWith(`${expectedPrefix}here is some text`);
+      expect(global.console.log.mock.calls.length).toEqual(nLogCalls);
       expect(global.console.dir.mock.calls.length).toBe(0);
-      if (newlineMethods.indexOf(method) > -1) {
-        expect(global.console.log.mock.calls)
-          .toEqual([[`${expectedPrefix}here is some text`], []]);
-      } else {
-        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
-      }
     });
   });
 
   twoArgMethods.forEach(({ method, expectedPrefix }) => {
     it(`logger.${method}: string as second argument`, () => {
+      const nLogCalls = newlineMethods.includes(method) ? 4 : 2;
       logger[method]('here is some text', 'and a second string argument');
-      expect(global.console.dir.mock.calls.length).toBe(0);
-      if (newlineMethods.indexOf(method) > -1) {
-        expect(global.console.log.mock.calls).toEqual(
-          [[`${expectedPrefix}here is some text\nand a second string argument`], []]
-        );
-      } else {
-        expect(global.console.log.mock.calls).toEqual(
-          [[`${expectedPrefix}here is some text\nand a second string argument`]]
-        );
-      }
+      logger[method]('here is some text', { description: 'and a second argument' });
+      expect(global.console.log).toBeCalledWith(`${expectedPrefix}here is some text\nand a second string argument`);
+      expect(global.console.log.mock.calls.length).toEqual(nLogCalls);
+      expect(global.console.dir.mock.calls.length).toBe(1);
     });
   });
 
   twoArgMethods.forEach(({ method, expectedPrefix }) => {
     it(`logger.${method}: object as second argument`, () => {
       const objectToLog = { description: 'and some object' };
+      const nLogCalls = newlineMethods.includes(method) ? 2 : 1;
       logger[method]('here is some text', objectToLog);
-      if (newlineMethods.indexOf(method) > -1) {
-        expect(global.console.log.mock.calls)
-          .toEqual([[`${expectedPrefix}here is some text`], []]);
-      } else {
-        expect(global.console.log.mock.calls).toEqual([[`${expectedPrefix}here is some text`]]);
-      }
+      expect(global.console.log).toBeCalledWith(`${expectedPrefix}here is some text`);
+      expect(global.console.log.mock.calls.length).toEqual(nLogCalls);
       expect(global.console.dir.mock.calls.length).toBe(1);
       expect(global.console.dir.mock.calls[0].length).toBe(2);
       expect(global.console.dir.mock.calls[0][0]).toBe(objectToLog);

--- a/cli/actions/__tests__/dev.test.js
+++ b/cli/actions/__tests__/dev.test.js
@@ -96,7 +96,7 @@ describe('dev', () => {
     // on restart
     expect(nodemon.on.mock.calls[0][0]).toBe('restart');
     nodemon.on.mock.calls[0][1]();
-    expect(logger.task).toBeCalledWith('Development server restarted');
+    expect(logger.end).toBeCalledWith('Development server restarted');
 
     // on quit
     expect(nodemon.on.mock.calls[1][0]).toBe('quit');

--- a/cli/actions/__tests__/start.test.js
+++ b/cli/actions/__tests__/start.test.js
@@ -9,9 +9,10 @@ describe('start', () => {
   const serverURL = { href: 'href' };
   start({ serverURL });
 
-  it('logs start and end', () => {
+  it('logs start, task and end', () => {
     expect(logger.start).toBeCalledWith('Starting production...');
-    expect(logger.end).toBeCalledWith(`Server running at ${serverURL.href}`);
+    expect(logger.task).toBeCalledWith(`Server running on ${serverURL.href}`);
+    expect(logger.end).toBeCalledWith('Production started');
   });
 
   it('executes the node process asynchronously', () => {

--- a/cli/actions/dev.js
+++ b/cli/actions/dev.js
@@ -56,7 +56,7 @@ module.exports = (config) => {
         logger.task(`Server running at: ${serverURL.href}`);
         logger.end('Development started');
       })
-      .on('restart', () => logger.task('Development server restarted'))
+      .on('restart', () => logger.end('Development server restarted'))
       .on('quit', process.exit);
   };
 

--- a/cli/actions/lintStyle.js
+++ b/cli/actions/lintStyle.js
@@ -28,8 +28,7 @@ module.exports = () => {
     if (result.output) {
       handleError(`\n${result.output}`);
     } else {
-      logger.log('');
-      logger.end('Your styles look good! ✨\n');
+      logger.end('Your styles look good! ✨');
       process.exit(0);
     }
   })

--- a/cli/actions/start.js
+++ b/cli/actions/start.js
@@ -7,5 +7,6 @@ const logger = require('./../logger');
 module.exports = (config) => {
   logger.start('Starting production...');
   shell.exec('node build/server/main.js', { async: true });
-  logger.end(`Server running at ${config.serverURL.href}`);
+  logger.task(`Server running on ${config.serverURL.href}`);
+  logger.end(`Production started`);
 };

--- a/cli/actions/start.js
+++ b/cli/actions/start.js
@@ -8,5 +8,5 @@ module.exports = (config) => {
   logger.start('Starting production...');
   shell.exec('node build/server/main.js', { async: true });
   logger.task(`Server running on ${config.serverURL.href}`);
-  logger.end(`Production started`);
+  logger.end('Production started');
 };

--- a/cli/logger.js
+++ b/cli/logger.js
@@ -5,11 +5,11 @@ const write = (status, text, verbose) => {
   let logObject = false;
 
   if (status === 'task') textToLog = '👍  ';
-  else if (status === 'start') textToLog = '🔥  ';
-  else if (status === 'end') textToLog = '✅  ';
+  else if (status === 'start') textToLog = '\n🔥  ';
+  else if (status === 'end') textToLog = '\n✅  ';
   else if (status === 'info') textToLog = 'ℹ️  ';
   else if (status === 'warn') textToLog = '🙀  ';
-  else if (status === 'error') textToLog = '❌  ';
+  else if (status === 'error') textToLog = '\n❌  ';
   else if (status === 'debug') textToLog = '🐞  ';
 
   textToLog += text;
@@ -24,6 +24,9 @@ const write = (status, text, verbose) => {
   }
 
   logger.log(textToLog);
+  if (['start', 'end', 'error'].indexOf(status) > -1) {
+    logger.log();
+  }
   if (logObject) logger.dir(verbose, { depth: 15 });
 };
 // Printing any statements

--- a/utils/kytConfig.js
+++ b/utils/kytConfig.js
@@ -28,6 +28,7 @@ module.exports = (optionalConfig) => {
   // Find user config
   if (shell.test('-f', kytConfigPath)) {
     try {
+      logger.log('');
       logger.info(`Using kyt config at ${kytConfigPath}`);
       // eslint-disable-next-line global-require,import/no-dynamic-require
       config = require(kytConfigPath);


### PR DESCRIPTION
This is pretty small. I added some newlines to the `start`, `end`, and `error` logs. The `dev` command looks like the following after a hot reload:

```

ℹ️  Using kyt config at /Users/202586/Sites/test.nytimes.com/kyt-starter-universal/kyt.config.js

🔥  Starting development build...

👍  Cleaned ./build
👍  Client webpack configuration compiled
👍  Server webpack configuration compiled
👍  Client build successful
👍  Setup React Hot Loader
👍  Client assets serving from http://localhost:3001/assets/
webpack built 7741101ff391e9a5c1c4 in 4316ms
👍  Server build successful
👍  Server running at: http://localhost:3000/

✅  Development started

webpack building...
👍  Client build successful
webpack built a38681c47339c9e21496 in 1188ms
👍  Server build successful

✅  Development server restarted

```