### PR TITLE
Adds the public directory path as a dev server static directory

### DIFF
--- a/__mocks__/express.js
+++ b/__mocks__/express.js
@@ -1,11 +1,14 @@
 const use = jest.fn();
 const listen = jest.fn();
+const statik = jest.fn();
+
 const expressMock = jest.fn(() => ({
   use,
   listen,
+  static: statik,
 }));
-
 
 module.exports = expressMock;
 module.exports.use = use;
 module.exports.listen = listen;
+module.exports.static = statik;

--- a/cli/actions/__tests__/dev.test.js
+++ b/cli/actions/__tests__/dev.test.js
@@ -61,7 +61,7 @@ describe('dev', () => {
     // start client
     expect(devMiddleware).toBeCalled();
     expect(express).toBeCalled();
-    expect(express.use.mock.calls.length).toBe(2);
+    expect(express.use.mock.calls.length).toBe(3);
     expect(express.listen).toBeCalledWith(port, hostname);
   });
 

--- a/cli/actions/dev.js
+++ b/cli/actions/dev.js
@@ -13,7 +13,7 @@ const logger = require('./../logger');
 const ifPortIsFreeDo = require('../../utils/ifPortIsFreeDo');
 const buildConfigs = require('../../utils/buildConfigs');
 const webpackCompiler = require('../../utils/webpackCompiler');
-const { buildPath, serverSrcPath } = require('../../utils/paths')();
+const { buildPath, serverSrcPath, publicSrcPath } = require('../../utils/paths')();
 
 module.exports = (config) => {
   logger.start('Starting development build...');
@@ -43,6 +43,7 @@ module.exports = (config) => {
 
     app.use(webpackDevMiddleware);
     app.use(hotMiddleware(clientCompiler));
+    app.use(express.static(publicSrcPath));
     app.listen(clientURL.port, clientURL.hostname);
   };
 

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -6,6 +6,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
+const url = require('url');
 const babel = require('./babel');
 const { buildPath, userNodeModulesPath } = require('../utils/paths')();
 
@@ -32,7 +33,9 @@ module.exports = options => ({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || options.environment),
       KYT: {
         SERVER_PORT: JSON.stringify((options.serverURL && options.serverURL.port) || ''),
+        SERVER_URL: JSON.stringify((options.serverURL && url.format(options.serverURL)) || ''),
         CLIENT_PORT: JSON.stringify((options.clientURL && options.clientURL.port) || ''),
+        CLIENT_URL: JSON.stringify((options.clientURL && url.format(options.clientURL)) || ''),
         PUBLIC_PATH: JSON.stringify(options.publicPath || ''),
         PUBLIC_DIR: JSON.stringify(options.publicDir || ''),
         ASSETS_MANIFEST:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -31,7 +31,9 @@ All `.js` files in `/src` are transpiled with Babel.
 kyt sets several global variables with useful information about the app environment.
 
 * `KYT.SERVER_PORT` Port your node server should listen on.
+* `KYT.SERVER_URL` URL of the backend server. For defaults and configuration, check out [`serverURL` in kyt.config.js configuration options](/docs/kytConfig.md#kytconfigjs-options).
 * `KYT.CLIENT_PORT` Port the client assets server is listening on.
+* `KYT.CLIENT_URL` URL for the client static/public directory. For defaults and configuration, check out [`clientURL` in kyt.config.js configuration options](/docs/kytConfig.md#kytconfigjs-options).
 * `KYT.PUBLIC_PATH` Full path for static assets server
 * `KYT.PUBLIC_DIR` Relative path to the public directory
 * `KYT.ASSETS_MANIFEST` Object with build assets paths


### PR DESCRIPTION
In `dev` the `src/public` directory assets aren't accessible. This configures the dev server to serve the public directory as a static directory. If you know of a better way to do this via webpack config, I'm all ears.

Fixes #223 