### PR TITLE
Chunkhash filenames

### DIFF
--- a/config/webpack.prod.client.js
+++ b/config/webpack.prod.client.js
@@ -26,7 +26,7 @@ module.exports = options => ({
 
   output: {
     path: assetsBuildPath,
-    filename: '[name]-[hash].js',
+    filename: '[name]-[chunkhash].js',
     chunkFilename: '[name]-[chunkhash].js',
     publicPath: options.publicPath,
     libraryTarget: 'var',


### PR DESCRIPTION
Use content-based `chunkhash` for production client bundle filenames. This helps with deterministic bundle chunking.

This would safely be a patch version.