### PR TITLE
Enable css-module jest support

### DIFF
--- a/config/__tests__/jest.test.js
+++ b/config/__tests__/jest.test.js
@@ -6,6 +6,7 @@ it('jest() returns a jest config', () => {
 
   expect(typeof jestConfig).toBe('object');
   expect(jestConfig.moduleNameMapper).toBeDefined();
+  expect(jestConfig.moduleNameMapper['^[./a-zA-Z0-9$_-]+\\.(css|scss)$']).toBe('identity-obj-proxy');
   expect(jestConfig.scriptPreprocessor).toBeDefined();
   expect(jestConfig.testPathIgnorePatterns).toBeDefined();
   expect(jestConfig.testEnvironment).toBeDefined();

--- a/config/jest.js
+++ b/config/jest.js
@@ -4,13 +4,13 @@ const resolveFromUtils = file => path.resolve(__dirname, '..', 'utils', 'jest', 
 
 // For configuration information, see:
 // https://facebook.github.io/jest/docs/api.html#configuration-options-configuration
+// For css and scss module name mapper see: https://facebook.github.io/jest/docs/tutorial-webpack.html
 module.exports = (rootDir, aliases = {}) => ({
   moduleNameMapper: Object.assign(
     {
       '^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$':
           resolveFromUtils('file.stub'),
-      '^[./a-zA-Z0-9$_-]+\\.(css|scss)$':
-          resolveFromUtils('style.stub'),
+      '^[./a-zA-Z0-9$_-]+\\.(css|scss)$': 'identity-obj-proxy',
     },
     aliases
   ),

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "filesize": "3.3.0",
     "glob": "7.1.0",
     "gzip-size": "3.0.0",
+    "identity-obj-proxy": "3.0.0",
     "inquirer": "1.2.1",
     "install": "0.8.1",
     "jest": "15.1.1",

--- a/utils/jest/style.stub.js
+++ b/utils/jest/style.stub.js
@@ -1,3 +1,3 @@
-// TODO: use https://github.com/keyanzhang/identity-obj-proxy
+// see: https://facebook.github.io/jest/docs/tutorial-webpack.html
 
-module.exports = {};
+module.exports = 'identity-obj-proxy';

--- a/utils/jest/style.stub.js
+++ b/utils/jest/style.stub.js
@@ -1,3 +1,0 @@
-// see: https://facebook.github.io/jest/docs/tutorial-webpack.html
-
-module.exports = 'identity-obj-proxy';


### PR DESCRIPTION
Enable css-module support in jest.

Issue: https://github.com/NYTimes/kyt/issues/257
For more details see: https://facebook.github.io/jest/docs/tutorial-webpack.html
