### PR TITLE
Overwrites default npm init test script on setup

### DIFF
--- a/cli/actions/setup.js
+++ b/cli/actions/setup.js
@@ -87,7 +87,7 @@ module.exports = (config, flags, args) => {
     }
 
     // This is the default test script added by 'npm init'.
-    const npmInitDefaultTestScript = 'echo \"Error: no test specified\" && exit 1'; // eslint-disable-line no-useless-escape
+    const npmInitDefaultTestScript = 'echo "Error: no test specified" && exit 1';
 
     commands.forEach((command) => {
       let commandName = command;

--- a/cli/actions/setup.js
+++ b/cli/actions/setup.js
@@ -86,6 +86,9 @@ module.exports = (config, flags, args) => {
       commands = uniq(commands.concat(tempScripts));
     }
 
+    // This is the default test script added by 'npm init'.
+    const npmInitDefaultTestScript = 'echo \"Error: no test specified\" && exit 1'; // eslint-disable-line no-useless-escape
+
     commands.forEach((command) => {
       let commandName = command;
 
@@ -96,7 +99,12 @@ module.exports = (config, flags, args) => {
         if (packageJson.scripts[commandName].includes('kyt') && !tempScripts.indexOf(command)) {
           return;
         }
-        commandName = `kyt:${commandName}`;
+
+        // Prefix except for when the command is 'test' and the script is
+        // the default from 'npm init'.
+        if (commandName !== 'test' || packageJson.scripts[commandName] !== npmInitDefaultTestScript) {
+          commandName = `kyt:${commandName}`;
+        }
       }
 
       // If the command is from a Starter-kyt then


### PR DESCRIPTION
# Issue

Addresses #288.
# Details

Previously, if a `test` script was found in `package.json`, `setup` would keep the original `test` script and create an additional `kyt:test` script that would run `kyt test`.

Now, `setup` checks to see if the existing `test` script is simply the `npm init` default of `echo \"Error: no test specified\" && exit 1`, and if so, overwrites `test` itself to be `kyt test`.  Note that the additional `kyt:test` script is no longer created in this case.
# Notes

Unit testing this code change proved difficult because it lives in a function internal to `setup`. There are currently no `setup` unit tests, and altering the [pkg.json](https://github.com/NYTimes/kyt/blob/master/e2e_tests/pkg.json) that the end-to-end tests load wasn't advisable.

As such, I have only manually verified these changes but the test cases would be:

| Scenario | Expected Behavior |
| --- | --- |
| `package.json` has `npm init` default test script | `test` script becomes `test: kyt test` |
| `package.json` has `test` script that is not the `npm init` default | `test` script is unaltered, and a new `kyt:test: kyt test` entry is added |
| `package.json` has no `test` script | `test: kyt test` script is added |

Happy hacktoberfest! 👻 🎃 👻 🎃 
