### PR TITLE
Add babel-plugin-transform-react-jsx-source to dev (#179)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
   "plugins": ["babel-plugin-transform-runtime"],
   "env": {
     "development": {
-      "plugins": []
+      "plugins": ["babel-plugin-transform-react-jsx-source"]
     },
     "production": {
       "plugins": [

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-jest": "16.0.0",
     "babel-loader": "6.2.5",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
+    "babel-plugin-transform-react-jsx-source": "6.9.0",
     "babel-plugin-transform-react-remove-prop-types": "0.2.9",
     "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-latest": "6.16.0",


### PR DESCRIPTION
Resolves #179. Added the new plugin definition to the root `.babelrc` to follow standard conventions. I tested the changes against the static starter-kyt by changing some of the prop requirements on one of the generated components. Here's a few screenshots of the before and after:

Before
<img width="560" alt="screen shot 2016-10-29 at 12 42 51 pm" src="https://cloud.githubusercontent.com/assets/1548189/19832390/8458012e-9dd7-11e6-9e08-287436d6e0d2.png">

After
<img width="544" alt="screen shot 2016-10-29 at 12 42 15 pm" src="https://cloud.githubusercontent.com/assets/1548189/19832392/8b6ea076-9dd7-11e6-96fb-b55ea540533c.png">

Also - I noticed the `.babelrc` doesn't support defining plugins and presets without the `babel-*` prefix because of the way they are being resolved in `config/babel.js`. I think I have a fix for this though, so I'm going to create an issue and open a separate PR.

Let me know if you have any questions!