### PR TITLE
Clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,19 @@ See our [config override instructions](/docs/kytConfig.md#modifywebpackconfig) f
 
 kyt includes a command line program with all the commands needed for development.
 
-`setup` includes these commands as scripts in your package.json:
+Running `node_modules/.bin/kyt setup` includes these commands as scripts in your package.json:
 
 ```
 npm run dev
 ```
 
-Or you can run a command using `node_modules/.bin/kyt command`
+Or you can run a command using `node_modules/.bin/kyt command`:
 
 ```
 node_modules/.bin/kyt build
 ```
+
+Here are the available commands:
 
 * [`setup`](/docs/commands.md#setup) sets up kyt and installs a starter-kyt
 * [`dev`](/docs/commands.md#dev) starts a development environment
@@ -102,7 +104,7 @@ See our [recipes](/docs/Recipes.md) for extending configuration.
 
 While kyt can be easily integrated into new or existing Node projects, it is even more powerful when used with a starter-kyt. A starter-kyt offers the benefits of boilerplates while minimizing the amount of new tools to learn and maintain. The kyt CLI includes a `setup` command which installs any preconfigured starter-kyt git repository, adding additional dependencies and building a source directory.
 
-See our recommended list of [starter-kyts](/docs/commands.md#recommended-starter-kyts)
+See our recommended list of [starter-kyts](/docs/commands.md#recommended-starter-kyts).
 
 ### How to build a starter-kyt
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,15 +11,15 @@ Or you can run a command with `node_modules/.bin/kyt command`
 node_modules/.bin/kyt build
 ```
 
-1. `setup` sets up kyt and installs a specified [starter-kyt](/docs/Starterkyts.md)
-2. `dev` starts up a development environment
-3. `build` compiles server and client code for production use
-4. `start` runs the production server
-5. `test` runs all tests in /src
-6. `proto` starts the prototyping app
-7. `lint` lints src code using ESLint
-8. `lint-style` lints src code using StyleLint
-9. `help` shows commands and their documentation
+1. [`setup`](/docs/commands.md#setup) sets up kyt and installs a specified [starter-kyt](/docs/Starterkyts.md)
+2. [`dev`](/docs/commands.md#setup) starts up a development environment
+3. [`build`](/docs/commands.md#setup) compiles server and client code for production use
+4. [`start`](/docs/commands.md#setup) runs the production server
+5. [`test`](/docs/commands.md#setup) runs all tests in /src
+6. [`proto`](/docs/commands.md#setup) starts the prototyping app
+7. [`lint`](/docs/commands.md#setup) lints src code using ESLint
+8. [`lint-style`](/docs/commands.md#setup) lints src code using StyleLint
+9. [`help`](/docs/commands.md#setup) shows commands and their documentation
 
 ## setup
 
@@ -178,7 +178,7 @@ The proto command also provides an `index.html` file with the following content:
 Running `proto` starts a dev server. Optionally, you can configure the prototype server url in your [kyt.config.js](/docs/kytConfig.md).
 
 ```
-✅  webpack-dev-server http://localhost:3002/prototype
+prototypeURL: "http://localhost:3002/prototype"
 ```
 
 ### Updating the prototype Webpack config

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,14 +12,14 @@ node_modules/.bin/kyt build
 ```
 
 1. [`setup`](/docs/commands.md#setup) sets up kyt and installs a specified [starter-kyt](/docs/Starterkyts.md)
-2. [`dev`](/docs/commands.md#setup) starts up a development environment
-3. [`build`](/docs/commands.md#setup) compiles server and client code for production use
-4. [`start`](/docs/commands.md#setup) runs the production server
-5. [`test`](/docs/commands.md#setup) runs all tests in /src
-6. [`proto`](/docs/commands.md#setup) starts the prototyping app
-7. [`lint`](/docs/commands.md#setup) lints src code using ESLint
-8. [`lint-style`](/docs/commands.md#setup) lints src code using StyleLint
-9. [`help`](/docs/commands.md#setup) shows commands and their documentation
+2. [`dev`](/docs/commands.md#dev) starts up a development environment
+3. [`build`](/docs/commands.md#build) compiles server and client code for production use
+4. [`start`](/docs/commands.md#start) runs the production server
+5. [`test`](/docs/commands.md#test) runs all tests in /src
+6. [`proto`](/docs/commands.md#proto) starts the prototyping app
+7. [`lint`](/docs/commands.md#lint) lints src code using ESLint
+8. [`lint-style`](/docs/commands.md#lint-style) lints src code using StyleLint
+9. [`help`](/docs/commands.md#help) shows commands and their documentation
 
 ## setup
 


### PR DESCRIPTION
#292 

The docs worked quite well. A few quick things:

- Make it clearer that `node_modules/.bin/kyt setup` is how you run the
  setup command for the first time.
- In docs/commands, make the list of commands at the top links
- Update the kyt.config.js example in `proto` to use the correct key