### PR TITLE
Support plugin/preset definitions without prefixes in .babelrc (#303)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,19 +1,19 @@
 {
-  "presets": ["babel-preset-react", ["babel-preset-latest", { "modules": false }]],
-  "plugins": ["babel-plugin-transform-runtime"],
+  "presets": ["react", ["latest", { "modules": false }]],
+  "plugins": ["transform-runtime"],
   "env": {
     "development": {
       "plugins": []
     },
     "production": {
       "plugins": [
-        "babel-plugin-transform-react-remove-prop-types",
-        "babel-plugin-transform-react-constant-elements"
+        "transform-react-remove-prop-types",
+        "transform-react-constant-elements"
       ]
     },
     "test": {
       "plugins": [
-        ["babel-plugin-transform-es2015-modules-commonjs", { "loose": true }]
+        ["transform-es2015-modules-commonjs", { "loose": true }]
       ]
     }
   }

--- a/config/babel.js
+++ b/config/babel.js
@@ -1,18 +1,39 @@
 const path = require('path');
 const fs = require('fs');
 
+/**
+ * Support preset and plugin definitions in .babelrc
+ * without the babel-* prefixes.
+ *
+ * E.g. {presets: ['babel-preset-react']} --> {presets: ['react']}
+ *
+ * @param  {String} prefix One of either 'babel-plugin' or 'babel-preset'
+ * @param  {String} dep    The dependency
+ * @return {String}        The normalized dependency
+ */
+const normalizeDep = (prefix, dep) => {
+  let resolved;
+  if (dep.indexOf('babel') !== 0) {
+    try {
+      resolved = require.resolve(`${prefix}-${dep}`);
+    } catch (e) { /* eslint-disable no-empty */ }
+  }
+
+  return resolved || require.resolve(dep);
+};
+
 // Uses require.resolve to add the full paths to all of the plugins
 // and presets, making sure that we handle the new array syntax.
 const resolvePluginsPresets = (babelGroup) => {
-  const resolve = (dep) => {
+  const resolve = (prefix, dep) => {
     if (typeof dep === 'object') {
-      dep[0] = require.resolve(dep[0]);
+      dep[0] = normalizeDep(prefix, dep[0]);
       return dep;
     }
-    return require.resolve(dep);
+    return normalizeDep(prefix, dep);
   };
-  babelGroup.plugins = (babelGroup.plugins || []).map(resolve);
-  babelGroup.presets = (babelGroup.presets || []).map(resolve);
+  babelGroup.plugins = (babelGroup.plugins || []).map(resolve.bind(null, 'babel-plugin'));
+  babelGroup.presets = (babelGroup.presets || []).map(resolve.bind(null, 'babel-preset'));
 };
 
 module.exports = (options) => {


### PR DESCRIPTION
Resolves #303. Still supports `babel-*` plugins and presets in `.babelrc`, as well as without the prefixes. Also still supports relative and absolute paths.
