### PR TITLE
Adds rfc template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,10 @@ We recommend forking kyt and creating a test project with a starter-kyt for loca
 ### Testing kyt
 Instructions TK
 
+## Create an RFC
+
+If you want to propose a large feature idea or architecture change you should consider submitting an RFC. It's often helpful to get feedback on your concept in an issue before starting the RFC. RFCs are an evolving process in the kyt repository so expect a lot of changes and guidelines in the future. You can find the kyt RFC template [here](/rfc/template.md).
+
 ## Build a starter-kyt
 
 Have a great idea for a boilerplate? Build it on top of kyt and let us know about it. Directions are [here](/docs/Starterkyts.md).

--- a/rfc/template.md
+++ b/rfc/template.md
@@ -1,0 +1,30 @@
+
+## Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+## Motivation
+[motivation]: #motivation
+
+This is the most important section in the RFC. Why are we doing this? What use cases does it support? What is the expected outcome? 
+
+## Detailed design
+[design]: #detailed-design
+
+Explain the design in enough detail for somebody familiar with kyt to understand, and for somebody familiar with the implementation to implement. This should get into specifics and corner-cases, and include examples of how the feature is used. Any new terminology should be defined here.
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+## Alternatives
+[alternatives]: #alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+## Unresolved questions
+[unresolved]: #unresolved-questions
+
+What parts of the design are still TBD?


### PR DESCRIPTION
We're testing a new rfc process in github Issues. So far the idea is to copy and use the rfc template from the Rust repository. We plan on working out the details for the process - how are rfcs labeled, what are their various stages, how are they accepted - as we roll out the first couple proposals.

Feel free to leave ideas here about the initial rfc process. I'll open an Issue so that we can further discuss the final process.