### PR TITLE
Run test from root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "ps-tree": "1.1.0",
     "shelljs": "0.7.5",
-    "jest": "17.0.3"
+    "jest": "16.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
     "doc": "docs"
   },
   "jest": {
-    "testPathIgnorePatterns": ["<rootDir>/packages/starter-kyts", "<rootDir>/e2e_tests"]
+    "testPathIgnorePatterns": [
+      "<rootDir>/packages/starter-kyts",
+      "<rootDir>/e2e_tests"
+    ]
   },
   "scripts": {
-    "test": "packages/kyt-core/node_modules/.bin/jest",
-    "test-watch": "packages/kyt-core/node_modules/.bin/jest --watch",
-    "test-coverage": "packages/kyt-core/node_modules/.bin/jest --coverage",
-    "e2e": "packages/kyt-core/node_modules/.bin/jest --config ./e2e_tests/jest.config.json --verbose --no-cache",
+    "test": "jest",
+    "test-watch": "jest --watch",
+    "test-coverage": "jest --coverage",
+    "e2e": "jest --config ./e2e_tests/jest.config.json --verbose --no-cache",
     "lint": "packages/kyt-core/node_modules/.bin/eslint --config packages/kyt-core/.eslintrc.json --ignore-pattern **/node_modules --ignore-pattern packages/starter-kyts ./"
   },
   "repository": {
@@ -28,6 +31,7 @@
   "homepage": "https://github.com/NYTimes/kyt#readme",
   "dependencies": {
     "ps-tree": "1.1.0",
-    "shelljs": "0.7.5"
+    "shelljs": "0.7.5",
+    "jest": "17.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
   "directories": {
     "doc": "docs"
   },
+  "jest": {
+    "testPathIgnorePatterns": ["<rootDir>/packages/starter-kyts", "<rootDir>/e2e_tests"]
+  },
   "scripts": {
-    "test": "jest --testPathPattern /__tests__/",
-    "e2e": "jest --config ./e2e_tests/jest.config.json --verbose --no-cache",
+    "test": "packages/kyt-core/node_modules/.bin/jest",
+    "test-watch": "packages/kyt-core/node_modules/.bin/jest --watch",
+    "test-coverage": "packages/kyt-core/node_modules/.bin/jest --coverage",
+    "e2e": "packages/kyt-core/node_modules/.bin/jest --config ./e2e_tests/jest.config.json --verbose --no-cache",
     "lint": "packages/kyt-core/node_modules/.bin/eslint --config packages/kyt-core/.eslintrc.json --ignore-pattern **/node_modules --ignore-pattern packages/starter-kyts ./"
   },
   "repository": {
@@ -22,7 +27,6 @@
   },
   "homepage": "https://github.com/NYTimes/kyt#readme",
   "dependencies": {
-    "jest": "16.0.2",
     "ps-tree": "1.1.0",
     "shelljs": "0.7.5"
   }

--- a/packages/kyt-cli/package.json
+++ b/packages/kyt-cli/package.json
@@ -7,11 +7,9 @@
     "kyt-cli": "index.js"
   },
   "scripts": {
-    "test": "jest --testPathPattern /__tests__/"
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "jest": "16.0.2"
   },
   "dependencies": {
     "commander": "2.9.0",

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -10,10 +10,6 @@
     "node": ">=6.1.0"
   },
   "scripts": {
-    "test": "jest --testPathPattern /__tests__/",
-    "e2e": "jest --config ./e2e_tests/jest.config.json --verbose --no-cache",
-    "test-watch": "jest --watch",
-    "test-coverage": "jest --coverage"
   },
   "repository": {
     "type": "git",

--- a/packages/kyt-utils/package.json
+++ b/packages/kyt-utils/package.json
@@ -4,10 +4,8 @@
   "description": "A shared kyt utility library.",
   "main": "logger.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "jest": "16.0.2"
   },
   "author": "NYTimes",
   "license": "Apache-2.0"


### PR DESCRIPTION
This adds the ability to test all of the packages from the root directory, removing the need for local packages to manage jest dependencies and scripts. ~~Since it needs to be there, we reference the jest dependency in the kyt-core package.~~ We'll still need to manage a separate jest dependency in kyt-core for user projects.