### PR TITLE
Adds kyt version option to setup command

### DIFF
--- a/packages/kyt-cli/cli/actions/setup.js
+++ b/packages/kyt-cli/cli/actions/setup.js
@@ -197,7 +197,7 @@ module.exports = (flags, args) => {
 
     // Add dependencies from starter-kyts
     if (!existingProject) {
-      const kytPrefVersion = args['kytVersion'] || checkStarterKytVersion(userPackageJSON);
+      const kytPrefVersion = args.kytVersion || checkStarterKytVersion(userPackageJSON);
       userPackageJSON = updatePackageJSONDependencies(userPackageJSON);
       addKytDevDependency(userPackageJSON, kytPrefVersion);
     } else {

--- a/packages/kyt-cli/cli/actions/setup.js
+++ b/packages/kyt-cli/cli/actions/setup.js
@@ -197,7 +197,7 @@ module.exports = (flags, args) => {
 
     // Add dependencies from starter-kyts
     if (!existingProject) {
-      const kytPrefVersion = checkStarterKytVersion(userPackageJSON);
+      const kytPrefVersion = args['kytVersion'] || checkStarterKytVersion(userPackageJSON);
       userPackageJSON = updatePackageJSONDependencies(userPackageJSON);
       addKytDevDependency(userPackageJSON, kytPrefVersion);
     } else {

--- a/packages/kyt-cli/cli/commands.js
+++ b/packages/kyt-cli/cli/commands.js
@@ -13,6 +13,7 @@ program
   .description('Generate a project from a github url to get started.')
   .option('-d, --directory <path>', 'Optional: Directory for your project. Defaults to your current working directory.')
   .option('-r, --repository [address]', 'Optional: Github repository address')
+  .option('-k, --kyt-version [version]', 'Optional: Version of kyt-core to install')
   .action(() => loadArgsAndDo(setupAction));
 
 


### PR DESCRIPTION
During local development, it's really hard to test cross-cutting package changes that involve kyt-core. To get around that I added an option to `kyt-cli setup` which gives you the ability to install a specific version of kyt. That way you can do something like the following when you're developing:

```
kyt-cli setup -d test -k file:../kyt/packages/kyt-core
```

It _might_ be useful to users too.