### PR TITLE
adds the babel presets to the bootstrap

### DIFF
--- a/scripts/get-packages.sh
+++ b/scripts/get-packages.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PACKAGES=( "" )
+PACKAGES=( "" "packages/babel-presets/babel-preset-kyt-core" "packages/babel-presets/babel-preset-kyt-react" )
 ROOT=`pwd`
 
 for DIR in packages/*; do


### PR DESCRIPTION
The preset packages have a common package directory so the bootstrap script wasn't finding their individual packages. Alternatively, we could move the presets to the root of the packages directory. 