### PR TITLE
fixes top level lint command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage
 **/node_modules
+packages/starter-kyts

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "./packages/eslint-config-kyt/eslintrc.json"
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - 6.0
-script: npm install && cd packages/kyt-core && npm install && cd ../kyt-cli && npm install && cd ../kyt-utils && npm install && cd ../.. && cd packages/eslint-config-kyt && npm install && npm run lint && npm test && npm run e2e
+script: npm run update && npm run lint && npm test && npm run e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: node_js
 node_js:
   - 6.0
-script: npm run update && npm run lint && npm test && npm run e2e
+script:
+  - npm i
+  - cd packages/kyt-core && npm i && cd -
+  - cd packages/kyt-cli && npm i && cd -
+  - cd packages/kyt-utils && npm i && cd -
+  - cd packages/eslint-config-kyt && npm i && cd -
+  - npm run lint && npm test && npm run e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: node_js
 node_js:
   - 6.0
-script:
-  - npm i
-  - cd packages/kyt-core && npm i && cd -
-  - cd packages/kyt-cli && npm i && cd -
-  - cd packages/kyt-utils && npm i && cd -
-  - cd packages/eslint-config-kyt && npm i && cd -
-  - npm run lint && npm test && npm run e2e
+script: npm run update && npm run lint && npm test && npm run e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - 6.0
-script: npm install && cd packages/kyt-core && npm install && cd ../kyt-cli && npm install && cd ../kyt-utils && npm install && cd ../.. && npm run lint && npm test && npm run e2e
+script: npm install && cd packages/kyt-core && npm install && cd ../kyt-cli && npm install && cd ../kyt-utils && npm install && cd ../.. && cd packages/eslint-config-kyt && npm install && npm run lint && npm test && npm run e2e

--- a/e2e_tests/utils/psKill.js
+++ b/e2e_tests/utils/psKill.js
@@ -3,7 +3,7 @@ const psTree = require('ps-tree');
 // Loops through processes and kills them
 module.exports = (pid, signal, callback) => {
   signal = signal || 'SIGKILL';
-  callback = callback || function () {};
+  callback = callback || function noop() {};
   psTree(pid, (err, children) => {
     let arr = [pid].concat(
       children.map(p => p.PID)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-watch": "jest --watch",
     "test-coverage": "jest --coverage",
     "e2e": "jest --config ./e2e_tests/jest.config.json --verbose --no-cache",
-    "lint": "packages/kyt-core/node_modules/.bin/eslint --config packages/kyt-core/.eslintrc.json --ignore-pattern **/node_modules --ignore-pattern packages/babel-presets --ignore-pattern packages/starter-kyts ./"
+    "lint": "packages/eslint-config-kyt/node_modules/.bin/eslint ./"
   },
   "repository": {
     "type": "git",

--- a/packages/babel-presets/babel-preset-kyt-core/.eslintrc.json
+++ b/packages/babel-presets/babel-preset-kyt-core/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "no-var": 0
+    "no-var": 0,
+    "import/no-unresolved": 0
   }
 }

--- a/packages/babel-presets/babel-preset-kyt-core/lib/index.js
+++ b/packages/babel-presets/babel-preset-kyt-core/lib/index.js
@@ -2,7 +2,7 @@ var babelPresetLatest = require('babel-preset-latest');
 var babelTransformRuntime = require('babel-plugin-transform-runtime');
 var babelTransformModules = require('babel-plugin-transform-es2015-modules-commonjs');
 
-module.exports = function(context, opts) {
+module.exports = function getPresetCore(context, opts) {
   opts = opts || {};
   return {
     // modules are handled by webpack, don't transform them

--- a/packages/babel-presets/babel-preset-kyt-react/.eslintrc.json
+++ b/packages/babel-presets/babel-preset-kyt-react/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "no-var": 0
+    "no-var": 0,
+    "import/no-unresolved": 0
   }
 }

--- a/packages/babel-presets/babel-preset-kyt-react/lib/index.js
+++ b/packages/babel-presets/babel-preset-kyt-react/lib/index.js
@@ -5,7 +5,7 @@ var reactTransformInline = require('babel-plugin-transform-react-inline-elements
 var reactTransformJsxSource = require('babel-plugin-transform-react-jsx-source');
 var babelPresetKytCore = require('babel-preset-kyt-core');
 
-module.exports = function(context, opts) {
+module.exports = function getPresetReact(context, opts) {
   opts = opts || {};
   return {
     presets: [

--- a/packages/kyt-core/.eslintrc.json
+++ b/packages/kyt-core/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "./config/.eslintrc.base.json"
-  ]
-}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 source scripts/remove-modules.sh
 source scripts/install-modules.sh

--- a/scripts/get-packages.sh
+++ b/scripts/get-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PACKAGES=( "" )
 ROOT=`pwd`

--- a/scripts/install-modules.sh
+++ b/scripts/install-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 source scripts/get-packages.sh
 

--- a/scripts/remove-modules.sh
+++ b/scripts/remove-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 source scripts/get-packages.sh
 


### PR DESCRIPTION
Here's my idea: We should configure one top-level lint command that lints against all of the packages and that references our kyt linter configuration. That should simplify the monorepo and give us a chance to do some dog wolfing of our own linter configuration.