### PR TITLE
cleans up the package.jsons

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.0",
   "description": "<p align=\"center\"><img src=\"/images/kyt-logo-large.png\"></p>",
   "main": "index.js",
+  "author": "NYTimes",
+  "license": "Apache-2.0",
+  "repository": "git+https://github.com/nytimes/kyt",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
   "directories": {
     "doc": "docs"
   },
@@ -29,16 +34,6 @@
     "e2e": "jest --config ./e2e_tests/jest.config.json --verbose --no-cache",
     "lint": "packages/kyt-core/node_modules/.bin/eslint --config packages/kyt-core/.eslintrc.json --ignore-pattern **/node_modules --ignore-pattern packages/babel-presets --ignore-pattern packages/starter-kyts ./"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/NYTimes/kyt.git"
-  },
-  "author": "",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/NYTimes/kyt/issues"
-  },
-  "homepage": "https://github.com/NYTimes/kyt#readme",
   "dependencies": {
     "ps-tree": "1.1.0",
     "shelljs": "0.7.5",

--- a/packages/babel-presets/babel-preset-kyt-core/package.json
+++ b/packages/babel-presets/babel-preset-kyt-core/package.json
@@ -1,10 +1,13 @@
 {
   "name": "babel-preset-kyt-core",
   "version": "0.1.0-alpha.1",
-  "description": "an opinionated babel preset, best used with kyt",
+  "description": "An opinionated babel preset, best used with kyt",
   "main": "lib/index.js",
   "author": "NYTimes",
   "license": "Apache-2.0",
+  "repository": "git+https://github.com/nytimes/kyt/packages/kyt-babel-preset-core",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "6.16.0",
     "babel-plugin-transform-runtime": "6.15.0",

--- a/packages/babel-presets/babel-preset-kyt-react/package.json
+++ b/packages/babel-presets/babel-preset-kyt-react/package.json
@@ -1,10 +1,13 @@
 {
   "name": "babel-preset-kyt-react",
   "version": "0.1.0-alpha.1",
-  "description": "an opinionated babel preset for react apps, best used with kyt",
+  "description": "An opinionated babel preset for react apps, best used with kyt.",
   "main": "lib/index.js",
   "author": "NYTimes",
   "license": "Apache-2.0",
+  "repository": "git+https://github.com/nytimes/kyt/packages/kyt-babel-preset-react",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
   "dependencies": {
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-react-inline-elements": "^6.8.0",

--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -5,16 +5,9 @@
   "main": "eslintrc.json",
   "author": "NYTimes",
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=6.1.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nytimes/kyt.git"
-  },
-  "bugs": {
-    "url": "https://github.com/nytimes/kyt/issues"
-  },
+  "repository": "git+https://github.com/nytimes/kyt/packages/eslint-config-nyt",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
   "dependencies": {
     "eslint": "3.8.1",
     "eslint-config-airbnb": "12.0.0",

--- a/packages/kyt-cli/package.json
+++ b/packages/kyt-cli/package.json
@@ -1,16 +1,16 @@
 {
   "name": "kyt-cli",
   "version": "0.0.1-alpha.1",
-  "description": "",
+  "description": "CLI for setting up kyt projects.",
   "main": "index.js",
   "bin": {
     "kyt-cli": "index.js"
   },
-  "scripts": {
-  },
+  "author": "NYTimes",
   "license": "Apache-2.0",
-  "devDependencies": {
-  },
+  "repository": "git+https://github.com/nytimes/kyt/packages/kyt-cli",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
   "dependencies": {
     "commander": "2.9.0",
     "inquirer": "1.2.3",
@@ -19,5 +19,6 @@
     "semver": "5.3.0",
     "shelljs": "0.7.5",
     "simple-git": "1.62.0"
-  }
+  },
+  "keywords": ["kyt", "cli", "kyt-cli"]
 }

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -2,24 +2,17 @@
   "name": "kyt",
   "version": "0.3.0",
   "description": "kyt is a toolkit that encapsulates and manages the configuration for web apps.",
-  "main": "",
+  "author": "NYTimes",
+  "license": "Apache-2.0",
+  "repository": "git+https://github.com/nytimes/kyt/packages/kyt-core",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
   "bin": {
     "kyt": "cli/index.js"
   },
   "engines": {
     "node": ">=6.1.0"
   },
-  "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nytimes/kyt.git"
-  },
-  "author": "NYTimes",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/nytimes/kyt/issues"
-  },
-  "homepage": "https://github.com/nytimes/kyt#readme",
   "dependencies": {
     "assets-webpack-plugin": "3.4.0",
     "autoprefixer": "6.5.0",
@@ -64,5 +57,6 @@
     "webpack-hot-middleware": "2.13.0",
     "webpack-merge": "0.14.1",
     "webpack-node-externals": "1.5.4"
-  }
+  },
+  "keywords": ["kyt", "core", "kyt-core"]
 }

--- a/packages/kyt-utils/package.json
+++ b/packages/kyt-utils/package.json
@@ -2,11 +2,10 @@
   "name": "kyt-utils",
   "version": "0.0.1-alpha.1",
   "description": "A shared kyt utility library.",
-  "main": "logger.js",
-  "scripts": {
-  },
-  "devDependencies": {
-  },
   "author": "NYTimes",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": "git+https://github.com/nytimes/kyt/packages/kyt-utils",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
+  "main": "logger.js"
 }

--- a/packages/stylelint-config-kyt/package.json
+++ b/packages/stylelint-config-kyt/package.json
@@ -2,19 +2,11 @@
   "name": "stylelint-config-kyt",
   "version": "0.0.1",
   "description": "StyleLint configuration for kyt projects.",
-  "main": "stylelintrc.json",
   "author": "NYTimes",
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=6.1.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nytimes/kyt.git"
-  },
-  "bugs": {
-    "url": "https://github.com/nytimes/kyt/issues"
-  },
+  "repository": "git+https://github.com/nytimes/kyt/packages/stylelint-config-kyt",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
   "dependencies": {
     "stylelint": "7.5.0",
     "stylelint-config-standard": "14.0.0"


### PR DESCRIPTION
Tries to make all of the package.jsons consistent. Some of the packages were throwing npm install warnings, and were missing fields. 