### PR TITLE
remove deprecated ESLint rule `prefer-reflect`

### DIFF
--- a/packages/eslint-config-kyt/eslintrc.json
+++ b/packages/eslint-config-kyt/eslintrc.json
@@ -22,7 +22,6 @@
     "max-nested-callbacks": [2, { "max": 5 }],
     "constructor-super": 2,
     "no-this-before-super": 2,
-    "prefer-spread": 2,
     "no-warning-comments": [1, { "terms": ["todo", "fixme"], "location": "start" }],
     "react/sort-comp": 0,
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],


### PR DESCRIPTION
Not sure why we enabled this rule in the first place, but it’s been deemed [pointless](http://eslint.org/docs/rules/prefer-reflect) by ESLint’s maintainers. (I haven’t updated ESLint or any other dependencies in this p.r., out of caution, having shaved enough yak tonight.)