### PR TITLE
Adds babelrc starter kyt files to package config kyt.files

### DIFF
--- a/packages/starter-kyts/kyt-starter-static/package.json
+++ b/packages/starter-kyts/kyt-starter-static/package.json
@@ -6,14 +6,14 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nytimes/kyt/kyt-starter-static.git"
+    "url": "git+https://github.com/nytimes/kyt/packages/kyt-starter-static.git"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/nytimes/kyt/issues"
   },
-  "homepage": "https://github.com/nytimes/packages/kyt-starter-static#readme",
+  "homepage": "https://github.com/nytimes/kyt/packages/kyt-starter-static#readme",
   "kyt": {
     "files": [".babelrc"]
   },

--- a/packages/starter-kyts/kyt-starter-static/package.json
+++ b/packages/starter-kyts/kyt-starter-static/package.json
@@ -6,14 +6,17 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nytimes/kyt-starter-static.git"
+    "url": "git+https://github.com/nytimes/kyt/kyt-starter-static.git"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/nytimes/kyt-starter-static/issues"
+    "url": "https://github.com/nytimes/kyt/issues"
   },
-  "homepage": "https://github.com/nytimes/kyt-starter-static#readme",
+  "homepage": "https://github.com/nytimes/packages/kyt-starter-static#readme",
+  "kyt": {
+    "files": [".babelrc"]
+  },
   "dependencies": {
     "babel-preset-kyt-react": "0.1.0-alpha.1",
     "html-webpack-plugin": "^2.22.0",

--- a/packages/starter-kyts/kyt-starter-universal/package.json
+++ b/packages/starter-kyts/kyt-starter-universal/package.json
@@ -6,14 +6,17 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nytm/wf-kyt-starter-universal.git"
+    "url": "git+https://github.com/nytimes/kyt/packages/kyt-starter-universal.git"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/nytm/wf-kyt-starter-universal/issues"
+    "url": "https://github.com/nytimes/kyt/issues"
   },
-  "homepage": "https://github.com/nytm/wf-kyt-starter-universal#readme",
+  "homepage": "https://github.com/nytimes/kyt/packages/kyt-starter-universal#readme",
+  "kyt": {
+    "files": [".babelrc"]
+  },
   "dependencies": {
     "babel-preset-kyt-react": "0.1.0-alpha.1",
     "compression": "^1.6.2",


### PR DESCRIPTION
I couldn't test this, but we need to copy the starter kyt .babelrc files into the user projects since they configure the react presets.