### PR TITLE
adds stupport to setup local starter kyts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ We're looking for developers to help maintain kyt.
 See something you think we should address? Open an issue.
 
 ### Submitting a PR
+
 Please make sure all PRs are:
 
 1. linted (npm run lint)
@@ -13,10 +14,40 @@ Please make sure all PRs are:
 3. Connected to an issue
 
 ### kyt local development
-We recommend forking kyt and creating a test project with a starter-kyt for local development.
+
+Since kyt is a monorepo, it can be tricky to test local changes across packages. The following commands can assist in bootstrapping your local kyt repository:
+
+#### bootstrap
+
+Bootstrap` will set you up with a clean slate. Every time it is run, it will remove and re-install the node_modules across all of the kyt packages. It will also link `kyt-cli` so you can run it locally on the command line.
+
+From the root of kyt, run:
+
+`npm run bootstrap`
+
+#### update
+
+Update is useful after you pull down kyt with some minor changes. It will call `npm install` on all of the packages in the repository. For complicated changes to the repository, it is best to use `bootstrap`.
+
+From the root of kyt, run:
+
+`npm run update`
+
+#### Testing local kyt-core changes
+
+It is a common workflow to make changes to kyt-core and test them with `kyt-cli setup`. To get around installing the latest kyt-core, there's an option in setup where you can specify which version of kyt you want to reference. For instance, by executing the following locally, you can setup a directory called test and install your local version of kyt-core:
+
+`kyt-cli setup -d test -k file:../kyt/packages/kyt-core`
+
+#### Testing local starter-kyt changes
+
+To test setting up/installing local starter kyts, you need to specify the `--repository-path` option. The following command will create a test directory and install the given local kyt repository and reference the starter kyt using the given repository path.
+
+`kyt-cli setup -d test -r kyt/.git --repository-path packages/starter-kyts/kyt-starter-static`
 
 ### Testing kyt
-Instructions TK
+
+More instructions TK
 
 ## Create an RFC
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,42 +13,6 @@ Please make sure all PRs are:
 2. tested (npm test)
 3. Connected to an issue
 
-### kyt local development
-
-Since kyt is a monorepo, it can be tricky to test local changes across packages. The following commands can assist in bootstrapping your local kyt repository:
-
-#### bootstrap
-
-Bootstrap` will set you up with a clean slate. Every time it is run, it will remove and re-install the node_modules across all of the kyt packages. It will also link `kyt-cli` so you can run it locally on the command line.
-
-From the root of kyt, run:
-
-`npm run bootstrap`
-
-#### update
-
-Update is useful after you pull down kyt with some minor changes. It will call `npm install` on all of the packages in the repository. For complicated changes to the repository, it is best to use `bootstrap`.
-
-From the root of kyt, run:
-
-`npm run update`
-
-#### Testing local kyt-core changes
-
-It is a common workflow to make changes to kyt-core and test them with `kyt-cli setup`. To get around installing the latest kyt-core, there's an option in setup where you can specify which version of kyt you want to reference. For instance, by executing the following locally, you can setup a directory called test and install your local version of kyt-core:
-
-`kyt-cli setup -d test -k file:../kyt/packages/kyt-core`
-
-#### Testing local starter-kyt changes
-
-To test setting up/installing local starter kyts, you need to specify the `--repository-path` option. The following command will create a test directory and install the given local kyt repository and reference the starter kyt using the given repository path.
-
-`kyt-cli setup -d test -r kyt/.git --repository-path packages/starter-kyts/kyt-starter-static`
-
-### Testing kyt
-
-More instructions TK
-
 ## Create an RFC
 
 If you want to propose a large feature idea or architecture change you should consider submitting an RFC. It's often helpful to get feedback on your concept in an issue before starting the RFC. RFCs are an evolving process in the kyt repository so expect a lot of changes and guidelines in the future. You can find the kyt RFC template [here](/rfc/template.md).
@@ -57,3 +21,39 @@ If you want to propose a large feature idea or architecture change you should co
 
 Have a great idea for a boilerplate? Build it on top of kyt and let us know about it. Directions are [here](/docs/Starterkyts.md).
 We feature [recommended starter-kyts](/docs/commands.md#recommended-starter-kyts)
+
+## kyt local development
+
+Since kyt is a monorepo, it can be tricky to test local changes across packages. The following commands can assist in bootstrapping your local kyt repository:
+
+### bootstrap
+
+Bootstrap` will set you up with a clean slate. Every time it is run, it will remove and re-install the node_modules across all of the kyt packages. It will also link `kyt-cli` so you can run it locally on the command line.
+
+From the root of kyt, run:
+
+`npm run bootstrap`
+
+### update
+
+Update is useful after you pull down kyt with some minor changes. It will call `npm install` on all of the packages in the repository. For complicated changes to the repository, it is best to use `bootstrap`.
+
+From the root of kyt, run:
+
+`npm run update`
+
+### Testing local kyt-core changes
+
+It is a common workflow to make changes to kyt-core and test them with `kyt-cli setup`. To get around installing the latest kyt-core, there's an option in setup where you can specify which version of kyt you want to reference. For instance, by executing the following locally, you can setup a directory called test and install your local version of kyt-core:
+
+`kyt-cli setup -d test -k file:../kyt/packages/kyt-core`
+
+### Testing local starter-kyt changes
+
+To test setting up/installing local starter kyts, you need to specify the `--repository-path` option. The following command will create a test directory and install the given local kyt repository and reference the starter kyt using the given repository path.
+
+`kyt-cli setup -d test -r kyt/.git --repository-path packages/starter-kyts/kyt-starter-static`
+
+### Testing kyt
+
+More instructions TK

--- a/packages/kyt-cli/cli/actions/setup.js
+++ b/packages/kyt-cli/cli/actions/setup.js
@@ -395,11 +395,11 @@ module.exports = (flags, args) => {
   // setup tasks for starter-kyts
   const starterKytSetup = (starterName) => {
     logger.task(`Setting up the ${starterName} starter-kyt`);
-    starterName = starterName || 'specified';
     if (args.repositoryPath || starterName) {
       tmpDir = path.resolve(tmpDir, args.repositoryPath || starterKyts.supported[starterName].path);
       console.log(tmpDir);
     }
+    starterName = starterName || 'specified';
     const afterClone = (error) => {
       if (error) {
         logger.error('There was a problem cloning the repository');

--- a/packages/kyt-cli/cli/actions/setup.js
+++ b/packages/kyt-cli/cli/actions/setup.js
@@ -394,12 +394,12 @@ module.exports = (flags, args) => {
 
   // setup tasks for starter-kyts
   const starterKytSetup = (starterName) => {
-    logger.task(`Setting up the ${starterName} starter-kyt`);
     if (args.repositoryPath || starterName) {
       tmpDir = path.resolve(tmpDir, args.repositoryPath || starterKyts.supported[starterName].path);
       console.log(tmpDir);
     }
     starterName = starterName || 'specified';
+    logger.task(`Setting up the ${starterName} starter-kyt`);
     const afterClone = (error) => {
       if (error) {
         logger.error('There was a problem cloning the repository');

--- a/packages/kyt-cli/cli/actions/setup.js
+++ b/packages/kyt-cli/cli/actions/setup.js
@@ -396,7 +396,6 @@ module.exports = (flags, args) => {
   const starterKytSetup = (starterName) => {
     if (args.repositoryPath || starterName) {
       tmpDir = path.resolve(tmpDir, args.repositoryPath || starterKyts.supported[starterName].path);
-      console.log(tmpDir);
     }
     starterName = starterName || 'specified';
     logger.task(`Setting up the ${starterName} starter-kyt`);

--- a/packages/kyt-cli/cli/actions/setup.js
+++ b/packages/kyt-cli/cli/actions/setup.js
@@ -394,8 +394,12 @@ module.exports = (flags, args) => {
 
   // setup tasks for starter-kyts
   const starterKytSetup = (starterName) => {
-    starterName = starterName || 'specified';
     logger.task(`Setting up the ${starterName} starter-kyt`);
+    starterName = starterName || 'specified';
+    if (args.repositoryPath || starterName) {
+      tmpDir = path.resolve(tmpDir, args.repositoryPath || starterKyts.supported[starterName].path);
+      console.log(tmpDir);
+    }
     const afterClone = (error) => {
       if (error) {
         logger.error('There was a problem cloning the repository');
@@ -435,7 +439,6 @@ module.exports = (flags, args) => {
       },
     ];
     inquire.prompt(question).then((answer) => {
-      tmpDir = path.join(tmpRepo, starterKyts.supported[answer.starterChoice].path);
       starterKytSetup(answer.starterChoice);
     });
   };

--- a/packages/kyt-cli/cli/commands.js
+++ b/packages/kyt-cli/cli/commands.js
@@ -12,9 +12,10 @@ const loadArgsAndDo = (action) => {
 program
   .command('setup')
   .description('Generate a project from a github url to get started.')
-  .option('-d, --directory <path>', 'Optional: Directory for your project. Defaults to your current working directory.')
+  .option('-d, --directory <path>', 'Optional: Creates the given directory name and installs there. Defaults to your current working directory.')
   .option('-r, --repository [address]', 'Optional: Github repository address')
   .option('-k, --kyt-version [version]', 'Optional: Version of kyt-core to install')
+  .option('--repository-path [path]', 'Optional: path within a repository for the main starter kyt directory. Default is the root directory of a git clone.')
   .action(() => loadArgsAndDo(setupAction));
 
 program


### PR DESCRIPTION
It's hard to test `kyt-cli setup` against local starter kyt changes. To get around this I added a new option to specify a repository path so that we can clone a local repository:

`kyt-cli setup -d test -r kyt/.git --repository-path packages/starter-kyts/kyt-starter-static`

Since it is mostly only useful for developers I left it undocumented in the user documentation but added it, along with some other recent changes, to the CONTRIBUTING.md doc.