### PR TITLE
Match imports by file ext in Jest test config

### DIFF
--- a/packages/kyt-core/config/__tests__/jest.test.js
+++ b/packages/kyt-core/config/__tests__/jest.test.js
@@ -24,7 +24,7 @@ it('jestConfig().moduleNameMapper matches by extension', () => {
 
   const matchers = Object
     .keys(config.moduleNameMapper)
-    .map((k) => new RegExp(k));
+    .map(k => new RegExp(k));
 
   const cssPath = './styles.css';
   const globalCssPath = 'style!css!./styles.css';

--- a/packages/kyt-core/config/__tests__/jest.test.js
+++ b/packages/kyt-core/config/__tests__/jest.test.js
@@ -14,3 +14,26 @@ it('jestConfig() returns a jest config', () => {
   expect(config.collectCoverageFrom).toBeDefined();
   expect(config.rootDir).toBe(rootDir);
 });
+
+it('jestConfig().moduleNameMapper matches by extension', () => {
+  const rootDir = 'rootDir';
+  const config = jestConfig(rootDir);
+
+  expect(typeof config).toBe('object');
+  expect(config.moduleNameMapper).toBeDefined();
+
+  const matchers = Object
+    .keys(config.moduleNameMapper)
+    .map((k) => new RegExp(k))
+
+  const cssPath = './styles.css';
+  const globalCssPath = 'style!css!./styles.css';
+  const jpgPath = './cats.jpg';
+  const jpgPathWithWebpackLoader = 'my-loader!./cats.jpg';
+
+  expect(matchers.some((matcher) => cssPath.match(matcher))).toBeTruthy();
+  expect(matchers.some((matcher) => globalCssPath.match(matcher))).toBeTruthy();
+  expect(matchers.some((matcher) => jpgPath.match(matcher))).toBeTruthy();
+  expect(matchers.some((matcher) => jpgPathWithWebpackLoader.match(matcher))).toBeTruthy();
+});
+

--- a/packages/kyt-core/config/__tests__/jest.test.js
+++ b/packages/kyt-core/config/__tests__/jest.test.js
@@ -24,16 +24,16 @@ it('jestConfig().moduleNameMapper matches by extension', () => {
 
   const matchers = Object
     .keys(config.moduleNameMapper)
-    .map((k) => new RegExp(k))
+    .map((k) => new RegExp(k));
 
   const cssPath = './styles.css';
   const globalCssPath = 'style!css!./styles.css';
   const jpgPath = './cats.jpg';
   const jpgPathWithWebpackLoader = 'my-loader!./cats.jpg';
 
-  expect(matchers.some((matcher) => cssPath.match(matcher))).toBeTruthy();
-  expect(matchers.some((matcher) => globalCssPath.match(matcher))).toBeTruthy();
-  expect(matchers.some((matcher) => jpgPath.match(matcher))).toBeTruthy();
-  expect(matchers.some((matcher) => jpgPathWithWebpackLoader.match(matcher))).toBeTruthy();
+  expect(matchers.some(matcher => cssPath.match(matcher))).toBeTruthy();
+  expect(matchers.some(matcher => globalCssPath.match(matcher))).toBeTruthy();
+  expect(matchers.some(matcher => jpgPath.match(matcher))).toBeTruthy();
+  expect(matchers.some(matcher => jpgPathWithWebpackLoader.match(matcher))).toBeTruthy();
 });
 

--- a/packages/kyt-core/config/jest.js
+++ b/packages/kyt-core/config/jest.js
@@ -7,9 +7,9 @@ const resolveFromUtils = file => path.resolve(__dirname, '..', 'utils', 'jest', 
 module.exports = (rootDir, aliases = {}) => ({
   moduleNameMapper: Object.assign(
     {
-      '^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$':
+      '\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$':
           resolveFromUtils('file.stub'),
-      '^[./a-zA-Z0-9$_-]+\\.(css|scss)$':
+      '\\.(css|scss)$':
           resolveFromUtils('style.stub'),
       // when this is removed from the base webpack config, we can likely
       // remove the runtime and include the polyfill in the test environment

--- a/packages/kyt-core/config/jest.js
+++ b/packages/kyt-core/config/jest.js
@@ -7,7 +7,7 @@ const resolveFromUtils = file => path.resolve(__dirname, '..', 'utils', 'jest', 
 module.exports = (rootDir, aliases = {}) => ({
   moduleNameMapper: Object.assign(
     {
-      '\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$':
+      '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
           resolveFromUtils('file.stub'),
       '\\.(css|scss)$':
           resolveFromUtils('style.stub'),


### PR DESCRIPTION
### Issue
#362 

The regex in the Jest `moduleNameMapper` isn't matching modules that are prefixed with Webpack loaders (e.g. `import 'styles!css!./styles.css`) , so modules aren't being stubbed.

### Changes
Updated the regex to only match modules by file extension.

cc @tizmagik 