### PR TITLE
Expand version range of yarn for Travis

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -34,7 +34,7 @@ const shell = require('shelljs');
 const semver = require('semver');
 
 // Make sure that we're all using the same version of yarn.
-const yarnVersionRequirement = '>=0.19.0';
+const yarnVersionRequirement = '>=0.20.0';
 const yarnVersion = shell.exec('yarn --version').stdout;
 if (!semver.satisfies(yarnVersion, yarnVersionRequirement)) {
   console.log('❌  update your version of yarn:', `npm i yarn@${yarnVersionRequirement} -g`);

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -34,7 +34,7 @@ const shell = require('shelljs');
 const semver = require('semver');
 
 // Make sure that we're all using the same version of yarn.
-const yarnVersionRequirement = '^0.19.0';
+const yarnVersionRequirement = '>=0.19.0';
 const yarnVersion = shell.exec('yarn --version').stdout;
 if (!semver.satisfies(yarnVersion, yarnVersionRequirement)) {
   console.log('❌  update your version of yarn:', `npm i yarn@${yarnVersionRequirement} -g`);


### PR DESCRIPTION
### Issue
[Yarn on Travis](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Travis-CI-supports-yarn) is installed as the latest, which is now 0.20.3. Our bootstrap.js file checks for 0.19.0, so builds fail with:

```
0.20.3
❌  update your version of yarn: npm i yarn@^0.19.0 -g
```

I have >= 0.19.0 for now unless there's a tighter version range we want.