### PR TITLE
Pass through webpack instance to modifyWebpack functions

### DIFF
--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -39,7 +39,7 @@ if (options.type === 'client') {
 In `kyt.config.js`
 
 ```javascript
-modifyWebpackConfig: (baseConfig, options) => {
+modifyWebpackConfig: (baseConfig, options, webpack) => {
   baseConfig.resolve.alias = {
     'myAliasFolder': path.resolve(process.cwd(), './src/path/to/my/folder'),
   }
@@ -51,7 +51,7 @@ modifyWebpackConfig: (baseConfig, options) => {
 
 in `kyt.config.js`
 ```javascript   
-modifyWebpackConfig: (baseConfig, options) => {
+modifyWebpackConfig: (baseConfig, options, webpack) => {
 
   baseConfig.plugins.push(
     new webpack.LoaderOptionsPlugin({
@@ -68,7 +68,7 @@ modifyWebpackConfig: (baseConfig, options) => {
 
 ## Update browser list for autoprefixer
 ```javascript
-modifyWebpackConfig: (baseConfig, options) => {
+modifyWebpackConfig: (baseConfig, options, webpack) => {
   baseConfig.plugins.push(
     new webpack.LoaderOptionsPlugin({
       options: {

--- a/packages/kyt-core/utils/buildConfigs.js
+++ b/packages/kyt-core/utils/buildConfigs.js
@@ -5,6 +5,7 @@
 const merge = require('webpack-merge');
 const logger = require('kyt-utils/logger');
 const clone = require('ramda').clone;
+const webpack = require('webpack')
 // base configs
 const baseConfig = require('../config/webpack.base');
 // dev configs
@@ -49,8 +50,8 @@ module.exports = (config, environment = 'development') => {
 
   // Modify via userland config
   try {
-    clientConfig = config.modifyWebpackConfig(clone(clientConfig), clientOptions);
-    serverConfig = config.modifyWebpackConfig(clone(serverConfig), serverOptions);
+    clientConfig = config.modifyWebpackConfig(clone(clientConfig), clientOptions, webpack);
+    serverConfig = config.modifyWebpackConfig(clone(serverConfig), serverOptions, webpack);
   } catch (error) {
     logger.error('Error in your kyt.config.js modifyWebpackConfig():', error);
     process.exit(1);

--- a/packages/kyt-core/utils/buildConfigs.js
+++ b/packages/kyt-core/utils/buildConfigs.js
@@ -2,10 +2,11 @@
 // Compiles the {server, client} configurations
 // For use by the client and server compilers.
 
+const webpack = require('webpack');
 const merge = require('webpack-merge');
 const logger = require('kyt-utils/logger');
 const clone = require('ramda').clone;
-const webpack = require('webpack')
+
 // base configs
 const baseConfig = require('../config/webpack.base');
 // dev configs


### PR DESCRIPTION
This passes kyt's version of webpack to the user's `modifyWebpack` function as another argument. The user thus does not need to install webpack themselves for simple things like adding a postcss plugin or another webpack flag.