### PR TITLE
fix: changed dirname and filename config in webpack configs

### DIFF
--- a/packages/kyt-core/config/webpack.dev.server.js
+++ b/packages/kyt-core/config/webpack.dev.server.js
@@ -18,8 +18,8 @@ module.exports = options => ({
   target: 'node',
 
   node: {
-    __dirname: false,
-    __filename: false,
+    __dirname: true,
+    __filename: true,
   },
 
   externals: nodeExternals(),

--- a/packages/kyt-core/config/webpack.prod.server.js
+++ b/packages/kyt-core/config/webpack.prod.server.js
@@ -22,8 +22,8 @@ module.exports = options => ({
   target: 'node',
 
   node: {
-    __dirname: false,
-    __filename: false,
+    __dirname: true,
+    __filename: true,
   },
 
   externals: nodeExternals(),


### PR DESCRIPTION
`dirname` and `filename` are both currently set to false in both `prd` and `dev` server configs. Although in `webpack.base.js` they are set to true. When these configs are set to false in the webpack config it changes the relativity of the Node global objects `__dirname` and `__filename`. When they are set to false  `__dirname` and `__filename` will return paths relative to the `build` directory. When these configs are set to true the will return paths relative to the file that you call them in.

**Screenshots:**
- console log `__dirname` in `src/server/index.js` with configs set to false: https://cl.ly/0D3k1C2K0g3k
- console log `__dirname` in `src/server/index.js` with configs set to true: https://cl.ly/1F371r0X1k20