### PR TITLE
fixes static public path for noServer configuration

### DIFF
--- a/packages/kyt-core/__mocks__/express.js
+++ b/packages/kyt-core/__mocks__/express.js
@@ -1,11 +1,13 @@
 const use = jest.fn();
 const listen = jest.fn();
+const wannabeStatic = jest.fn();
 const expressMock = jest.fn(() => ({
   use,
   listen,
+  static: wannabeStatic,
 }));
-
 
 module.exports = expressMock;
 module.exports.use = use;
 module.exports.listen = listen;
+module.exports.static = wannabeStatic;

--- a/packages/kyt-core/cli/actions/__tests__/dev.test.js
+++ b/packages/kyt-core/cli/actions/__tests__/dev.test.js
@@ -50,6 +50,7 @@ describe('dev', () => {
       express,
       express.use,
       express.listen,
+      express.static,
       ifPortIsFreeDo,
       webpackCompiler,
       buildConfigs,
@@ -165,6 +166,8 @@ describe('dev', () => {
       'should not set up chokidar watchers');
     assert.equal(ifPortIsFreeDo.mock.calls.length, 1,
       'should only call ifPortIsFreeDo once');
+    assert.equal(express.static.mock.calls.length, 1,
+      'should call express.static once');
   });
 
   it('handles multiple server entries', () => {

--- a/packages/kyt-core/cli/actions/dev.js
+++ b/packages/kyt-core/cli/actions/dev.js
@@ -13,7 +13,7 @@ const logger = require('kyt-utils/logger');
 const ifPortIsFreeDo = require('../../utils/ifPortIsFreeDo');
 const buildConfigs = require('../../utils/buildConfigs');
 const webpackCompiler = require('../../utils/webpackCompiler');
-const { buildPath, serverSrcPath } = require('kyt-utils/paths')();
+const { buildPath, serverSrcPath, publicSrcPath } = require('kyt-utils/paths')();
 
 module.exports = (config, flags) => {
   logger.start('Starting development build...');
@@ -44,6 +44,7 @@ module.exports = (config, flags) => {
 
     app.use(webpackDevMiddleware);
     app.use(hotMiddleware(clientCompiler));
+    if (!hasServer) app.use(express.static(publicSrcPath));
     app.listen(clientURL.port, clientURL.hostname);
   };
 

--- a/packages/kyt-starter-static/README.md
+++ b/packages/kyt-starter-static/README.md
@@ -22,6 +22,8 @@ The following are some of the tools included in this starter-kyt:
 
 - You will find a `src/index.ejs` file which gets compiled to an html file by the html webpack plugin. See more for configuration in the kyt.config.js. After a build, kyt will copy the html build into `build/public`.
 
+- Assets from `src/public` are accessible from `/` in both `dev` and production (`build`).
+
 - As a performance optimization, React Router routes are loaded dynamically and chunked separately using the ES2015 `System.import` directive. See more about  [Webpack 2 support](https://gist.github.com/sokra/27b24881210b56bbaff7#code-splitting-with-es6) and [dynamic routing](https://github.com/reactjs/react-router/blob/master/docs/guides/DynamicRouting.md).
 
 ## How To Contribute


### PR DESCRIPTION
This works because in `dev` the public assets should be accessible to the index. After a production `build` all of the public assets are copied next to the index file.

fixes #419 