### PR TITLE
Updates stylelint-config-kyt allowing use of CSS Modules pseudo selectors

### DIFF
--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -59,7 +59,7 @@
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
     "stylelint": "7.9.0",
-    "stylelint-config-kyt": "0.3.0",
+    "stylelint-config-kyt": "0.3.1",
     "stylelint-config-standard": "16.0.0",
     "temp": "0.8.3",
     "url-loader": "0.5.7",

--- a/packages/stylelint-config-kyt/README.md
+++ b/packages/stylelint-config-kyt/README.md
@@ -138,6 +138,11 @@ Default values can be used when it's convenient
 
 ## Changelog
 
+**0.3.1** - 03/28/17
+This release ensures using CSS modules selectors such as :global and :local
+don't trigger invalid stylelint errors. Useful when using libraries such as
+react-addons-css-transition-group.
+
 **0.3.0** - 03/23/17
 
 This release upgrades Stylelint from [7.5.0 to 7.9.0](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md) and stylelint-config-standard from [14.0.0 to 16.0.0](https://github.com/stylelint/stylelint-config-standard/blob/master/CHANGELOG.md).

--- a/packages/stylelint-config-kyt/package.json
+++ b/packages/stylelint-config-kyt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-kyt",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "stylelintrc.json",
   "description": "StyleLint configuration for kyt projects.",
   "author": "NYTimes",

--- a/packages/stylelint-config-kyt/stylelintrc.json
+++ b/packages/stylelint-config-kyt/stylelintrc.json
@@ -4,6 +4,10 @@
   "rules": {
     "string-quotes": "single",
     "selector-no-id": true,
-    "property-no-unknown": [true, {"ignoreProperties": ["composes"]}]
+    "property-no-unknown": [true, {"ignoreProperties": ["composes"]}],
+    "selector-pseudo-class-no-unknown": [ true, {
+      "ignorePseudoClasses": ["export", "import", "global", "local"],
+    }],
+    "at-rule-no-unknown": [ true, {"ignoreAtRules": ["value"]}],
   }
 }


### PR DESCRIPTION
This should fix issue #444 

Note: The lockfiles aren't updated yet. I'm guessing the update to stylelint-config-kyt needs to be published before yarn can find them?