### PR TITLE
Add connect-history-api-fallback middleware for client-only apps in dev

### DIFF
--- a/packages/kyt-core/cli/actions/__tests__/dev.test.js
+++ b/packages/kyt-core/cli/actions/__tests__/dev.test.js
@@ -170,7 +170,6 @@ describe('dev', () => {
       'should call express.static once');
     assert.equal(express.use.mock.calls.length, 4,
       'should set up four express middlewares');
-
   });
 
   it('handles multiple server entries', () => {

--- a/packages/kyt-core/cli/actions/__tests__/dev.test.js
+++ b/packages/kyt-core/cli/actions/__tests__/dev.test.js
@@ -168,6 +168,9 @@ describe('dev', () => {
       'should only call ifPortIsFreeDo once');
     assert.equal(express.static.mock.calls.length, 1,
       'should call express.static once');
+    assert.equal(express.use.mock.calls.length, 4,
+      'should set up four express middlewares');
+
   });
 
   it('handles multiple server entries', () => {

--- a/packages/kyt-core/cli/actions/dev.js
+++ b/packages/kyt-core/cli/actions/dev.js
@@ -7,6 +7,7 @@ const express = require('express');
 const shell = require('shelljs');
 const devMiddleware = require('webpack-dev-middleware');
 const hotMiddleware = require('webpack-hot-middleware');
+const history = require('connect-history-api-fallback');
 const nodemon = require('nodemon');
 const once = require('lodash.once');
 const logger = require('kyt-utils/logger');
@@ -44,7 +45,10 @@ module.exports = (config, flags) => {
 
     app.use(webpackDevMiddleware);
     app.use(hotMiddleware(clientCompiler));
-    if (!hasServer) app.use(express.static(publicSrcPath));
+    if (!hasServer) {
+      app.use(history());
+      app.use(express.static(publicSrcPath));
+    }
     app.listen(clientURL.port, clientURL.hostname);
   };
 

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -25,6 +25,7 @@
     "babel-preset-kyt-core": "0.2.0",
     "chokidar": "1.6.0",
     "commander": "2.9.0",
+    "connect-history-api-fallback": "^1.3.0",
     "css-loader": "0.26.1",
     "detect-port": "1.0.1",
     "eslint": "3.18.0",

--- a/packages/kyt-core/yarn.lock
+++ b/packages/kyt-core/yarn.lock
@@ -4894,8 +4894,8 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 rc@^1.0.1, rc@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.7.tgz#c5ea564bb07aff9fd3a5b32e906c1d3a65940fea"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.0.tgz#c7de973b7b46297c041366b2fd3d2363b1697c66"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"

--- a/packages/kyt-starter-static/starter-src/yarn.lock
+++ b/packages/kyt-starter-static/starter-src/yarn.lock
@@ -1927,7 +1927,11 @@ domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
 
-domelementtype@1, domelementtype@~1.1.1:
+domelementtype@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
@@ -2503,8 +2507,8 @@ fb-watchman@^2.0.0:
     bser "^2.0.0"
 
 fbjs@^0.8.1:
-  version "0.8.11"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.11.tgz#340b590b8a2278a01ef7467c07a16da9b753db24"
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -5382,8 +5386,8 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 rc@^1.0.1, rc@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.7.tgz#c5ea564bb07aff9fd3a5b32e906c1d3a65940fea"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.0.tgz#c7de973b7b46297c041366b2fd3d2363b1697c66"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"

--- a/packages/kyt-starter-universal/starter-src/yarn.lock
+++ b/packages/kyt-starter-universal/starter-src/yarn.lock
@@ -2421,8 +2421,8 @@ fb-watchman@^2.0.0:
     bser "^2.0.0"
 
 fbjs@^0.8.1:
-  version "0.8.11"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.11.tgz#340b590b8a2278a01ef7467c07a16da9b753db24"
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -5197,8 +5197,8 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 rc@^1.0.1, rc@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.7.tgz#c5ea564bb07aff9fd3a5b32e906c1d3a65940fea"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.0.tgz#c7de973b7b46297c041366b2fd3d2363b1697c66"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"


### PR DESCRIPTION
Per the chat in #457 — opening this as a conversation starter. 

I didn't add docs yet, in part because I'm not sure where the best place for them is.

The use case for this is that I have a client-side SPA that in staging and production has a reverse proxy that resolves all URL requests to the entry page (published at index.html). React Router takes care of the routing from there. The history-api middleware here accomplishes something very similar.
