### PR TITLE
add KYT.EXECUTION_ENVIRONMENT global

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -36,6 +36,7 @@ kyt sets several global variables with useful information about the app environm
 * `KYT.PUBLIC_PATH` Full path for static assets server
 * `KYT.PUBLIC_DIR` Relative path to the public directory
 * `KYT.ASSETS_MANIFEST` Object with build assets paths
+* `KYT.BUNDLE_TYPE` Where this code is running: `"server"` or `"client"`
 
 For examples of how to use these environment variables, checkout out the simple React [starter-kyt](https://github.com/nytimes/kyt-starter)
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -36,7 +36,7 @@ kyt sets several global variables with useful information about the app environm
 * `KYT.PUBLIC_PATH` Full path for static assets server
 * `KYT.PUBLIC_DIR` Relative path to the public directory
 * `KYT.ASSETS_MANIFEST` Object with build assets paths
-* `KYT.BUNDLE_TYPE` Where this code is running: `"server"` or `"client"`
+* `KYT.EXECUTION_ENVIRONMENT` Where this code is running: `"server"` or `"client"`
 
 For examples of how to use these environment variables, checkout out the simple React [starter-kyt](https://github.com/nytimes/kyt-starter)
 

--- a/packages/kyt-core/config/__tests__/webpack.test.js
+++ b/packages/kyt-core/config/__tests__/webpack.test.js
@@ -78,6 +78,6 @@ describe('webpack.base', () => {
   });
   it('sets up a DefinePlugin entry for options.type', () => {
     baseConfig({ clientURL: {}, publicPath: '/', type: 'foo' });
-    expect(webpack.DefinePlugin.mock.calls[0][0].KYT.BUNDLE_TYPE).toBe('"foo"');
+    expect(webpack.DefinePlugin.mock.calls[0][0].KYT.EXECUTION_ENVIRONMENT).toBe('"foo"');
   });
 });

--- a/packages/kyt-core/config/__tests__/webpack.test.js
+++ b/packages/kyt-core/config/__tests__/webpack.test.js
@@ -60,6 +60,7 @@ describe('webpack.prod.server', () => {
 describe('webpack.base', () => {
   beforeEach(() => {
     logger.warn.mockClear();
+    webpack.DefinePlugin.mockClear();
   });
   it('doesn\'t set up a babel preset if a .babelrc exists', () => {
     shell.test.mockImplementationOnce(() => true);
@@ -74,5 +75,9 @@ describe('webpack.base', () => {
     const babelLoader = config.module.rules.find(({ loader }) => loader === 'babel-loader');
     expect(babelLoader.options.presets.length).toBe(1);
     expect(babelLoader.options.presets[0]).toMatch(/babel-preset-kyt-core/);
+  });
+  it('sets up a DefinePlugin entry for options.type', () => {
+    const config = baseConfig({ clientURL: {}, publicPath: '/', type: 'foo' });
+    expect(webpack.DefinePlugin.mock.calls[0][0].KYT.BUNDLE_TYPE).toBe('"foo"');
   });
 });

--- a/packages/kyt-core/config/__tests__/webpack.test.js
+++ b/packages/kyt-core/config/__tests__/webpack.test.js
@@ -77,7 +77,7 @@ describe('webpack.base', () => {
     expect(babelLoader.options.presets[0]).toMatch(/babel-preset-kyt-core/);
   });
   it('sets up a DefinePlugin entry for options.type', () => {
-    const config = baseConfig({ clientURL: {}, publicPath: '/', type: 'foo' });
+    baseConfig({ clientURL: {}, publicPath: '/', type: 'foo' });
     expect(webpack.DefinePlugin.mock.calls[0][0].KYT.BUNDLE_TYPE).toBe('"foo"');
   });
 });

--- a/packages/kyt-core/config/webpack.base.js
+++ b/packages/kyt-core/config/webpack.base.js
@@ -38,6 +38,7 @@ module.exports = (options) => {
           CLIENT_PORT: JSON.stringify((options.clientURL && options.clientURL.port) || ''),
           PUBLIC_PATH: JSON.stringify(options.publicPath || ''),
           PUBLIC_DIR: JSON.stringify(options.publicDir || ''),
+          BUNDLE_TYPE: JSON.stringify(options.type || ''),
           ASSETS_MANIFEST:
               JSON.stringify(path.join(buildPath || '', options.clientAssetsFile || '')),
         },

--- a/packages/kyt-core/config/webpack.base.js
+++ b/packages/kyt-core/config/webpack.base.js
@@ -38,7 +38,7 @@ module.exports = (options) => {
           CLIENT_PORT: JSON.stringify((options.clientURL && options.clientURL.port) || ''),
           PUBLIC_PATH: JSON.stringify(options.publicPath || ''),
           PUBLIC_DIR: JSON.stringify(options.publicDir || ''),
-          BUNDLE_TYPE: JSON.stringify(options.type || ''),
+          EXECUTION_ENVIRONMENT: JSON.stringify(options.type || ''),
           ASSETS_MANIFEST:
               JSON.stringify(path.join(buildPath || '', options.clientAssetsFile || '')),
         },


### PR DESCRIPTION
fixes #331 

passes the `type` variable into a global, `KYT.EXECUTION_ENVIRONMENT`; totally open to suggestions on a better name