### PR TITLE
move react-hot-loader after babel-polyfill

### DIFF
--- a/packages/kyt-core/config/webpack.dev.client.js
+++ b/packages/kyt-core/config/webpack.dev.client.js
@@ -22,7 +22,9 @@ module.exports = (options) => {
     `${clientSrcPath}/index.js`,
   ];
 
-  if (options.reactHotLoader) main.unshift('react-hot-loader/patch');
+  // Because of an ie11 bug, 'react-hot-loader/patch' needs to come after 'babel-polyfill'
+  // https://github.com/facebook/react/issues/8379#issuecomment-273489824
+  if (options.reactHotLoader) main.splice(main.indexOf('babel-polyfill') + 1, 0, 'react-hot-loader/patch');
 
   return {
     target: 'web',


### PR DESCRIPTION
Because of an ie11 bug, 'react-hot-loader/patch' needs to come after 'babel-polyfill'.

https://github.com/facebook/react/issues/8379#issuecomment-273489824