### PR TITLE
update eslint-plugin-jsx-a11y to 5.0.3

### DIFF
--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -13,7 +13,7 @@
     "eslint-config-airbnb": "14.1.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-jsx-a11y": "4.0.0",
+    "eslint-plugin-jsx-a11y": "5.0.3",
     "eslint-plugin-react": "6.10.0"
   },
   "keywords": [

--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -14,7 +14,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-jsx-a11y": "5.0.3",
-    "eslint-plugin-react": "6.10.0"
+    "eslint-plugin-react": "7.0.1"
   },
   "keywords": [
     "kyt",

--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/nytimes/kyt#readme",
   "peerDependencies": {
     "eslint": "3.19.0",
-    "eslint-config-airbnb": "14.1.0",
+    "eslint-config-airbnb": "15.0.1",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -33,7 +33,7 @@
     "eslint-config-kyt": "0.3.2",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-jsx-a11y": "4.0.0",
+    "eslint-plugin-jsx-a11y": "5.0.3",
     "eslint-plugin-react": "6.10.0",
     "express": "4.14.0",
     "extract-text-webpack-plugin": "2.0.0-rc.3",

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -29,7 +29,7 @@
     "css-loader": "0.26.1",
     "detect-port": "1.0.1",
     "eslint": "3.19.0",
-    "eslint-config-airbnb": "14.1.0",
+    "eslint-config-airbnb": "15.0.1",
     "eslint-config-kyt": "0.3.2",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-json": "1.2.0",

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-jsx-a11y": "5.0.3",
-    "eslint-plugin-react": "6.10.0",
+    "eslint-plugin-react": "7.0.1",
     "express": "4.14.0",
     "extract-text-webpack-plugin": "2.0.0-rc.3",
     "file-loader": "0.10.0",


### PR DESCRIPTION
Updates the eslint-plugin-jsx-a11y to include updated rules. We'd like to use this one specifically:

https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/91