### PR TITLE
Update node-sass to latest version

### DIFF
--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -52,7 +52,7 @@
     "lodash.clonedeep": "4.5.0",
     "lodash.merge": "4.6.0",
     "lodash.once": "4.1.1",
-    "node-sass": "4.5.0",
+    "node-sass": "4.5.3",
     "nodemon": "1.10.2",
     "postcss-loader": "2.0.5",
     "prettier": "1.5.2",


### PR DESCRIPTION
The current version of node-sass has no bindings available for Node 8. Since Node 8 is going to be LTS pretty soon it might be nice to upgrade to node-sass. It even has the added benefit of being able to run the universal app on an Alpine environment.