### PR TITLE
Downgrades ESLint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,14 +85,14 @@
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
     },
     "ajv": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-      "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -319,7 +319,7 @@
       "integrity": "sha1-l7yFTH0Ll5+NZIneVHoNF/swf20=",
       "requires": {
         "browserslist": "2.5.1",
-        "caniuse-lite": "1.0.30000749",
+        "caniuse-lite": "1.0.30000750",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.13",
@@ -1675,7 +1675,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.5.1.tgz",
       "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
       "requires": {
-        "caniuse-lite": "1.0.30000749",
+        "caniuse-lite": "1.0.30000750",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -1769,7 +1769,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000749",
+        "caniuse-db": "1.0.30000750",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -1779,21 +1779,21 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000749",
+            "caniuse-db": "1.0.30000750",
             "electron-to-chromium": "1.3.27"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000749",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000749.tgz",
-      "integrity": "sha1-VWdzqjqnBPWB10j6Y7RsoIeqxn0="
+      "version": "1.0.30000750",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000750.tgz",
+      "integrity": "sha1-Px+FySyRNO3ac1aV42nX4XZ1K3U="
     },
     "caniuse-lite": {
-      "version": "1.0.30000749",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000749.tgz",
-      "integrity": "sha1-L/OChlrq2MyjXaz7qwT1jv+kwBw="
+      "version": "1.0.30000750",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000750.tgz",
+      "integrity": "sha1-OK0ZqkxtiNo46JANNma047u2XCI="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2842,7 +2842,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000749",
+            "caniuse-db": "1.0.30000750",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -2854,7 +2854,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000749",
+            "caniuse-db": "1.0.30000750",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -3542,7 +3542,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
       "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
       "requires": {
-        "ajv": "5.2.4",
+        "ajv": "5.3.0",
         "babel-code-frame": "6.26.0",
         "chalk": "2.2.0",
         "concat-stream": "1.6.0",
@@ -3697,7 +3697,7 @@
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "requires": {
         "debug": "2.6.9",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "eslint-module-utils": {
@@ -4123,6 +4123,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5453,7 +5458,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.2.4",
+        "ajv": "5.3.0",
         "har-schema": "2.0.0"
       }
     },
@@ -5513,7 +5518,7 @@
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
         "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "sntp": "2.0.3"
       }
     },
     "he": {
@@ -6935,7 +6940,7 @@
       "requires": {
         "browser-resolve": "1.11.2",
         "is-builtin-module": "1.0.0",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "jest-resolve-dependencies": {
@@ -9897,7 +9902,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000749",
+            "caniuse-db": "1.0.30000750",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -10946,7 +10951,7 @@
         "loglevel-colored-level-prefix": "1.0.0",
         "messageformat": "1.0.2",
         "prettier-eslint": "8.2.1",
-        "rxjs": "5.5.0",
+        "rxjs": "5.5.2",
         "yargs": "8.0.2"
       },
       "dependencies": {
@@ -11403,7 +11408,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "redbox-react": {
@@ -11713,9 +11718,9 @@
       "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE="
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -11786,9 +11791,9 @@
       }
     },
     "rxjs": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.0.tgz",
-      "integrity": "sha512-vmvP5y/oJIJmXKHY36PIjVeI/46Sny6BMBa7/ou2zsNz1PiqU/Gtcz1GujnHz5Qlxncv+J9VlWmttnshqFj3Kg==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
+      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "requires": {
         "symbol-observable": "1.0.4"
       }
@@ -11959,7 +11964,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "5.2.4"
+        "ajv": "5.3.0"
       }
     },
     "scss-tokenizer": {
@@ -12181,9 +12186,9 @@
       }
     },
     "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.3.tgz",
+      "integrity": "sha512-2MJj0Qh4KCTWspRKX5TW88agdryzOtulhm7aSS96iXl5Xm22ME5E7E9I7soFPCbeHUkmo4lHImoznvCCjz1byQ==",
       "requires": {
         "hoek": "4.2.0"
       }
@@ -12590,7 +12595,7 @@
           "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
           "requires": {
             "browserslist": "2.5.1",
-            "caniuse-lite": "1.0.30000749",
+            "caniuse-lite": "1.0.30000750",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "6.0.13",
@@ -12732,7 +12737,7 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "requires": {
-        "ajv": "5.2.4",
+        "ajv": "5.3.0",
         "ajv-keywords": "2.1.0",
         "chalk": "2.2.0",
         "lodash": "4.17.4",
@@ -13362,7 +13367,7 @@
       "requires": {
         "acorn": "5.1.2",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.2.4",
+        "ajv": "5.3.0",
         "ajv-keywords": "2.1.0",
         "async": "2.5.0",
         "enhanced-resolve": "3.4.1",

--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -9,22 +9,17 @@
   "bugs": "https://github.com/nytimes/kyt/issues",
   "homepage": "https://github.com/nytimes/kyt#readme",
   "peerDependencies": {
-    "babel-eslint": "8.0.1",
-    "eslint": "4.9.0",
-    "eslint-config-airbnb": "16.1.0",
+    "babel-eslint": "7.1.1",
+    "eslint": "3.19.0",
+    "eslint-config-airbnb": "15.0.2",
     "eslint-config-prettier": "2.6.0",
-    "eslint-plugin-import": "2.8.0",
+    "eslint-plugin-import": "2.7.0",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-jsx-a11y": "6.0.2",
+    "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-prettier": "2.3.1",
-    "eslint-plugin-react": "7.4.0",
+    "eslint-plugin-react": "7.1.0",
     "prettier": "1.7.4",
     "prettier-eslint-cli": "4.4.0"
   },
-  "keywords": [
-    "kyt",
-    "eslint",
-    "config",
-    "eslint-config"
-  ]
+  "keywords": ["kyt", "eslint", "config", "eslint-config"]
 }


### PR DESCRIPTION
Internally, we found problems with some of the recent ESLint upgrades so I downgraded them to their previous versions. Prettier upgrades seem to work, and keeping Prettier upgraded and working is a higher priority than ESLint for now.