### PR TITLE
updating fs.writeFile to be node >= 9 compatible

### DIFF
--- a/packages/kyt-core/config/webpack.base.js
+++ b/packages/kyt-core/config/webpack.base.js
@@ -70,7 +70,7 @@ module.exports = options => {
           } else {
             // Merge the server assets into the client assets and write the result to disk.
             const assets = merge({}, clientAssets, manifest.toJSON());
-            fs.writeFile(assetsFilePath, JSON.stringify(assets, null, '  '), 'utf8');
+            fs.writeFile(assetsFilePath, JSON.stringify(assets, null, '  '), 'utf8', function(err) {});
           }
         },
         customize: (key, value) => {

--- a/packages/kyt-core/config/webpack.base.js
+++ b/packages/kyt-core/config/webpack.base.js
@@ -70,7 +70,7 @@ module.exports = options => {
           } else {
             // Merge the server assets into the client assets and write the result to disk.
             const assets = merge({}, clientAssets, manifest.toJSON());
-            fs.writeFile(assetsFilePath, JSON.stringify(assets, null, '  '), 'utf8', function(err) {});
+            fs.writeFile(assetsFilePath, JSON.stringify(assets, null, '  '), 'utf8', () => {});
           }
         },
         customize: (key, value) => {


### PR DESCRIPTION
I was running into this error on node `v10.1.0`. Without an explicit callback, this will throw a `ERR_INVALID_CALLBACK` error.