### PR TITLE
fileExtensions.js: add ^[./a-zA-Z0-9!&$_-]+

### DIFF
--- a/packages/kyt-core/config/fileExtensions.js
+++ b/packages/kyt-core/config/fileExtensions.js
@@ -1,2 +1,2 @@
 module.exports =
-  '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|ico)$';
+  '^[./a-zA-Z0-9!&$_-]+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|ico)$';


### PR DESCRIPTION
This change to the fileExtensions regex works around an issue seen in wf-project-vi: https://github.com/nytm/wf-project-vi/pull/5957#issuecomment-417087289