### PR TITLE
Fix the Order of Hash Plugin

### DIFF
--- a/packages/kyt-core/config/webpack.prod.client.js
+++ b/packages/kyt-core/config/webpack.prod.client.js
@@ -58,6 +58,12 @@ module.exports = options => ({
   },
 
   plugins: [
+    // Webpack fingerprinting can break sometimes, this plugin will
+    // guarantee that our hashes are deterministic, every build.
+    new HashOutput({
+      manifestFiles: ['manifest'],
+    }),
+
     new ExtractTextPlugin({
       filename: '[name]-[contenthash].css',
       allChunks: true,
@@ -98,11 +104,5 @@ module.exports = options => ({
 
     // Scope Hoisting
     new webpack.optimize.ModuleConcatenationPlugin(),
-
-    // Webpack fingerprinting can break sometimes, this plugin will
-    // guarantee that our hashes are deterministic, every build.
-    new HashOutput({
-      manifestFiles: ['manifest'],
-    }),
   ],
 });

--- a/packages/kyt-core/utils/buildConfigs.js
+++ b/packages/kyt-core/utils/buildConfigs.js
@@ -51,7 +51,7 @@ module.exports = (config, environment = 'development') => {
   }
 
   // Merge options with static webpack configs
-  clientConfig = merge.smart(clientConfig(clientOptions), baseConfig(clientOptions));
+  clientConfig = merge.smartStrategy({ plugins: 'prepend' })(baseConfig(clientOptions), clientConfig(clientOptions));
   serverConfig = merge.smart(baseConfig(serverOptions), serverConfig(serverOptions));
 
   // Modify via userland config

--- a/packages/kyt-core/utils/buildConfigs.js
+++ b/packages/kyt-core/utils/buildConfigs.js
@@ -51,7 +51,7 @@ module.exports = (config, environment = 'development') => {
   }
 
   // Merge options with static webpack configs
-  clientConfig = merge.smart(baseConfig(clientOptions), clientConfig(clientOptions));
+  clientConfig = merge.smart(clientConfig(clientOptions), baseConfig(clientOptions));
   serverConfig = merge.smart(baseConfig(serverOptions), serverConfig(serverOptions));
 
   // Modify via userland config

--- a/packages/kyt-core/utils/buildConfigs.js
+++ b/packages/kyt-core/utils/buildConfigs.js
@@ -51,7 +51,10 @@ module.exports = (config, environment = 'development') => {
   }
 
   // Merge options with static webpack configs
-  clientConfig = merge.smartStrategy({ plugins: 'prepend' })(baseConfig(clientOptions), clientConfig(clientOptions));
+  clientConfig = merge.smartStrategy({ plugins: 'prepend' })(
+    baseConfig(clientOptions),
+    clientConfig(clientOptions)
+  );
   serverConfig = merge.smart(baseConfig(serverOptions), serverConfig(serverOptions));
 
   // Modify via userland config


### PR DESCRIPTION
On the newest version (1.3.1 and later) of `webpack-plugin-hash-output`, kyt will build the following public files but have the wrong manifest.

`build/public/`:

```
home-bdaa12b95e14114e6fa8.js
home-fd1695f6705cb606af7b.js.map
icon-kytLogo_large-252x252-466d0df90a1887c34d04caa92ed278c6.svg
kyt-favicon.png
main-4cccd6c6738209ec0477.js
main-c0e5f197fc9a4f2ea0e9.js.map
main-cbd6d2c055eee169d7f3e3bcc1cbe40c.css
main-cbd6d2c055eee169d7f3e3bcc1cbe40c.css.map
manifest-12d6c8af40129f33e486.js.map
manifest-25b851bdb9006ad2f741.js
tools-81b34556e4309ec0bbac.js
tools-94ca7d3c5331b07dde98.js.map
vendor-19b99b1785ad4bdc8ef2.js.map
vendor-f291b70adc969b65e321.js
```

`build/publicAssets.json`:

```
{
  "home.js": "/home-fd1695f6705cb606af7b.js",
  "home.js.map": "/home-fd1695f6705cb606af7b.js.map",
  "icon-kytLogo_large-252x252.svg": "/icon-kytLogo_large-252x252-466d0df90a1887c34d04caa92ed278c6.svg",
  "main.css": "/main-cbd6d2c055eee169d7f3e3bcc1cbe40c.css",
  "main.css.map": "/main-cbd6d2c055eee169d7f3e3bcc1cbe40c.css.map",
  "main.js": "/main-c0e5f197fc9a4f2ea0e9.js",
  "main.js.map": "/main-c0e5f197fc9a4f2ea0e9.js.map",
  "manifest.js": "/manifest-12d6c8af40129f33e486.js",
  "manifest.js.map": "/manifest-12d6c8af40129f33e486.js.map",
  "tools.js": "/tools-94ca7d3c5331b07dde98.js",
  "tools.js.map": "/tools-94ca7d3c5331b07dde98.js.map",
  "vendor.js": "/vendor-19b99b1785ad4bdc8ef2.js",
  "vendor.js.map": "/vendor-19b99b1785ad4bdc8ef2.js.map"
}
```

This is because of this change in the `webpack-plugin-hash-output` library: https://github.com/scinos/webpack-plugin-hash-output/issues/24

This PR moves the `HashOutput` plugin to the very beginning of the plugin list.

This may not be the cleanest solution, so alternatively, we could just pin `webpack-plugin-hash-output` to `1.3.0`.