### PR TITLE
Add eslint-plugin-kyt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,6 +1733,11 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -5683,6 +5688,11 @@
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -8504,6 +8514,57 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+        }
       }
     },
     "modify-values": {

--- a/packages/eslint-config-kyt/eslintrc.json
+++ b/packages/eslint-config-kyt/eslintrc.json
@@ -6,7 +6,7 @@
     "browser": true
   },
 
-  "plugins": ["json", "prettier"],
+  "plugins": ["json", "prettier", "kyt"],
 
   "parser": "babel-eslint",
   "parserOptions": {
@@ -68,6 +68,7 @@
         "singleQuote": true,
         "trailingComma": "es5"
       }
-    ]
+    ],
+    "kyt/no-props-spread": 1
   }
 }

--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -16,6 +16,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-json": "1.3.2",
     "eslint-plugin-jsx-a11y": "6.1.2",
+    "eslint-plugin-kyt": "1.0.0-alpha.0",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.11.1",
     "prettier": "1.15.3"

--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-json": "1.3.2",
     "eslint-plugin-jsx-a11y": "6.1.2",
-    "eslint-plugin-kyt": "1.0.0-alpha.0",
+    "eslint-plugin-kyt": "pre",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.11.1",
     "prettier": "1.15.3"

--- a/packages/eslint-plugin-kyt/README.md
+++ b/packages/eslint-plugin-kyt/README.md
@@ -1,0 +1,1 @@
+# kyt ESLint Plugin

--- a/packages/eslint-plugin-kyt/lib/index.js
+++ b/packages/eslint-plugin-kyt/lib/index.js
@@ -1,0 +1,5 @@
+const noPropsSpread = require('./rules/no-props-spread');
+
+exports.rules = {
+  'no-props-spread': noPropsSpread,
+};

--- a/packages/eslint-plugin-kyt/lib/rules/no-props-spread.js
+++ b/packages/eslint-plugin-kyt/lib/rules/no-props-spread.js
@@ -1,0 +1,9 @@
+const message = 'Spreading React props deopts Babel transforms.';
+
+module.exports = function noPropsSpread(context) {
+  return {
+    JSXSpreadAttribute(node) {
+      context.report({ node, message });
+    },
+  };
+};

--- a/packages/eslint-plugin-kyt/package.json
+++ b/packages/eslint-plugin-kyt/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "eslint-plugin-kyt",
+  "version": "1.0.0-alpha.0",
+  "description": "ESLint plugin for kyt projects.",
+  "main": "lib/index.js",
+  "author": "NYTimes",
+  "license": "Apache-2.0",
+  "repository": "git+https://github.com/nytimes/kyt/packages/eslint-plugin-kyt",
+  "bugs": "https://github.com/nytimes/kyt/issues",
+  "homepage": "https://github.com/nytimes/kyt#readme",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "devDependencies": {
+    "mocha": "^5.2.0"
+  },
+  "scripts": {
+    "test": "mocha tests --recursive"
+  }
+}

--- a/packages/eslint-plugin-kyt/tests/no-props-spread.js
+++ b/packages/eslint-plugin-kyt/tests/no-props-spread.js
@@ -1,0 +1,32 @@
+const { RuleTester } = require('eslint');
+const rule = require('../lib/rules/no-props-spread');
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-props-spread', rule, {
+  valid: [
+    {
+      code: '<div id="foo"></div>',
+    },
+  ],
+  invalid: [
+    {
+      code: '<div {...{ id: "foo" }}></div>',
+      errors: [
+        {
+          message: 'Spreading React props deopts Babel transforms.',
+          type: 'JSXSpreadAttribute',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-json": "1.3.2",
     "eslint-plugin-jsx-a11y": "6.1.2",
-    "eslint-plugin-kyt": "1.0.0-alpha.0",
+    "eslint-plugin-kyt": "pre",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.11.1",
     "express": "4.15.3",

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-json": "1.3.2",
     "eslint-plugin-jsx-a11y": "6.1.2",
+    "eslint-plugin-kyt": "1.0.0-alpha.0",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.11.1",
     "express": "4.15.3",

--- a/packages/kyt-starter-universal/starter-src/src/server/index.js
+++ b/packages/kyt-starter-universal/starter-src/src/server/index.js
@@ -36,6 +36,7 @@ app.get('*', (request, response) => {
       // the components and assets into the template.
       response.status(200).send(
         template({
+          // eslint-disable-next-line kyt/no-props-spread
           root: renderToString(<RouterContext {...renderProps} />),
           manifestJSBundle: clientAssets['manifest.js'],
           mainJSBundle: clientAssets['main.js'],


### PR DESCRIPTION
Main purpose is to add the rule: `no-props-spread`

Spreading props on JSX components can cause Babel transforms to stop working. It also causes eslint-plugin-react to skip parsing its ruleset in the file containing the spread.