### PR TITLE
Adds eslint-plugin-react-hooks

### DIFF
--- a/packages/eslint-config-kyt/README.md
+++ b/packages/eslint-config-kyt/README.md
@@ -15,7 +15,7 @@ This is an extension of the Airbnb [**JavaScript**](https://github.com/airbnb/ja
 Note, installing `kyt` or setting up a starter-kyt will install this package automatically. If you want to install this linter extension separately, follow these install instructions. If you have `kyt` installed and you want to override the linter configuration, skip to step (2).
 
 1. Install the _eslint-config-kyt_ node module and its dependencies:  
-   `npm install eslint prettier eslint-config-kyt eslint-config-airbnb eslint-plugin-import eslint-plugin-json eslint-plugin-jsx-a11y eslint-plugin-react eslint-config-prettier eslint-plugin-prettier prettier-eslint-cli babel-eslint --save-dev`
+   `npm install eslint prettier eslint-config-kyt eslint-config-airbnb eslint-plugin-import eslint-plugin-json eslint-plugin-jsx-a11y eslint-plugin-react eslint-config-prettier eslint-plugin-prettier prettier-eslint-cli babel-eslint eslint-plugin-react-hooks --save-dev`
 2. Copy the following into an `.eslintrc` in your project:
 
 ```js

--- a/packages/eslint-config-kyt/eslintrc.json
+++ b/packages/eslint-config-kyt/eslintrc.json
@@ -1,5 +1,10 @@
 {
-  "extends": ["airbnb", "plugin:prettier/recommended", "prettier/react"],
+  "extends": [
+    "airbnb",
+    "plugin:prettier/recommended",
+    "prettier/react",
+    "react-hooks"
+  ],
 
   "env": {
     "jest": true,
@@ -19,6 +24,7 @@
   },
 
   "rules": {
+    "react-hooks/rules-of-hooks": "error",
     "no-lonely-if": 2,
     "no-nested-ternary": 2,
     "max-nested-callbacks": [2, { "max": 5 }],

--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-kyt": "pre",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "1.0.1",
     "prettier": "1.16.1"
   },
   "keywords": [

--- a/packages/kyt-core/package-lock.json
+++ b/packages/kyt-core/package-lock.json
@@ -1,7 +1,14 @@
 {
-	"requires": true,
+	"name": "kyt",
+	"version": "1.0.0-alpha.3",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"eslint-plugin-react-hooks": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.0.1.tgz",
+			"integrity": "sha512-yNhvY7EFBp0mq0Bt8BHoS57GwJ4e1qSYdvDFSfPnjmiSmyGUfQFQGcQs4K0JQFDGopWkURWq58psbUJIhWZ2Kg=="
+		},
 		"react-hot-loader": {
 			"version": "3.0.0-beta.6",
 			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.6.tgz",

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-kyt": "1.0.0-alpha.0",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.12.4",
-    "eslint-plugin-react-hooks": "^1.0.1",
+    "eslint-plugin-react-hooks": "1.0.1",
     "express": "4.16.4",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "0.10.1",

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-kyt": "1.0.0-alpha.0",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "^1.0.1",
     "express": "4.16.4",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "0.10.1",
@@ -66,14 +67,14 @@
     "temp": "0.9.0",
     "url-loader": "0.5.8",
     "webpack": "3.12.0",
-    "webpackbar": "3.1.5",
     "webpack-assets-manifest": "1.0.0",
     "webpack-dev-middleware": "2.0.6",
     "webpack-dev-server": "2.11.3",
     "webpack-hot-middleware": "2.24.3",
     "webpack-merge": "4.1.5",
     "webpack-node-externals": "1.7.2",
-    "webpack-plugin-hash-output": "1.3.1"
+    "webpack-plugin-hash-output": "1.3.1",
+    "webpackbar": "3.1.5"
   },
   "peerDependencies": {
     "@babel/polyfill": "7.2.5",


### PR DESCRIPTION
Relevant for React 16.8. More info on why this plugin is needed here: https://reactjs.org/docs/hooks-rules.html