### PR TITLE
Forward child exit in test command

### DIFF
--- a/packages/kyt-core/cli/actions/test.js
+++ b/packages/kyt-core/cli/actions/test.js
@@ -24,7 +24,9 @@ module.exports = (config, flags) => {
   process.env.KYT_ENV_TYPE = 'test';
 
   // Run Jest
-  child.spawn('jest', ['--config', JSON.stringify(jestConfig), ...flags], {
+  const testRunner = child.spawn('jest', ['--config', JSON.stringify(jestConfig), ...flags], {
     stdio: 'inherit',
   });
+
+  testRunner.on('exit', process.exit);
 };


### PR DESCRIPTION
In the test command, `process.exit` with the result of the spawned execution context.