### PR TITLE
Port some tweaks over from the nytimes codebase

### DIFF
--- a/packages/kyt-core/config/webpack.base.js
+++ b/packages/kyt-core/config/webpack.base.js
@@ -36,6 +36,9 @@ module.exports = options => {
     resolve: {
       extensions: ['.js', '.json'],
       modules: [userNodeModulesPath, path.resolve(__dirname, '../node_modules'), 'node_modules'],
+      // Not resolving "module" avoids issues with packages that specify entrypoints
+      // containing ES6 modules e.g., lodash-es, a transitive dependency of redux.
+      mainFields: ['main'],
     },
 
     resolveLoader: {

--- a/packages/kyt-core/config/webpack.dev.client.js
+++ b/packages/kyt-core/config/webpack.dev.client.js
@@ -34,6 +34,10 @@ module.exports = options => {
 
     devtool: 'cheap-module-eval-source-map',
 
+    resolve: {
+      mainFields: ['browser'],
+    },
+
     entry: {
       main,
     },

--- a/packages/kyt-core/config/webpack.dev.server.js
+++ b/packages/kyt-core/config/webpack.dev.server.js
@@ -5,6 +5,7 @@ const nodeExternals = require('webpack-node-externals');
 const { serverSrcPath, serverBuildPath, publicSrcPath } = require('kyt-utils/paths')();
 const postcssLoader = require('../utils/getPostcssLoader');
 const getPolyfill = require('../utils/getPolyfill');
+const devtoolModuleFilenameTemplate = require('../utils/devtoolModuleFilenameTemplate');
 
 const cssStyleLoaders = [
   {
@@ -42,6 +43,7 @@ module.exports = options => ({
     chunkFilename: '[name]-[chunkhash].js',
     publicPath: options.publicPath,
     libraryTarget: 'commonjs2',
+    devtoolModuleFilenameTemplate,
   },
 
   module: {

--- a/packages/kyt-core/config/webpack.prod.client.js
+++ b/packages/kyt-core/config/webpack.prod.client.js
@@ -27,6 +27,10 @@ module.exports = options => ({
 
   devtool: 'source-map',
 
+  resolve: {
+    mainFields: ['browser'],
+  },
+
   entry: {
     main: [getPolyfill(options.type), `${clientSrcPath}/index.js`].filter(Boolean),
   },

--- a/packages/kyt-core/config/webpack.prod.server.js
+++ b/packages/kyt-core/config/webpack.prod.server.js
@@ -5,6 +5,7 @@ const nodeExternals = require('webpack-node-externals');
 const { serverSrcPath, serverBuildPath, publicSrcPath } = require('kyt-utils/paths')();
 const postcssLoader = require('../utils/getPostcssLoader');
 const getPolyfill = require('../utils/getPolyfill');
+const devtoolModuleFilenameTemplate = require('../utils/devtoolModuleFilenameTemplate');
 
 const cssStyleLoaders = [
   {
@@ -42,6 +43,7 @@ module.exports = options => ({
     chunkFilename: '[name]-[chunkhash].js',
     publicPath: options.publicPath,
     libraryTarget: 'commonjs2',
+    devtoolModuleFilenameTemplate,
   },
 
   module: {

--- a/packages/kyt-core/utils/devtoolModuleFilenameTemplate.js
+++ b/packages/kyt-core/utils/devtoolModuleFilenameTemplate.js
@@ -1,0 +1,23 @@
+// source map customizations
+// references in a source map's "sources" property are relative and need to resolve differently based on the context
+
+const path = require('path');
+const { serverSrcPath } = require('kyt-utils/paths')();
+
+// configure for debugging locally (via `npm run dev-inspect` and attaching a debugger to that process)
+// in the local debugging context, source map sources need to resolve relative to the
+// source's location on disk ... here, we make sure to account for the `./build/server` target destination
+// for example:
+// given the file `$HOME/project/src/server/metricsHandler.js`, the path in `build/server/main.js.map`'s "sources" property for this file
+// should be `../../src/server/metricsHandler.js`
+//
+// dynamically set the source map's "sources" paths
+module.exports = info => {
+  const { resourcePath, absoluteResourcePath } = info;
+  // skip these
+  if (/^(webpack|external)/.test(resourcePath)) {
+    return `${resourcePath}`;
+  }
+  // return a relative path that resolves according to the debugging context
+  return path.relative(serverSrcPath, absoluteResourcePath);
+};


### PR DESCRIPTION
- better es6 resolving
- better support for `node --inspect` source maps