### PR TITLE
Use getPostcssLoader in webpack.proto.js

### DIFF
--- a/packages/kyt-core/config/webpack.proto.js
+++ b/packages/kyt-core/config/webpack.proto.js
@@ -4,6 +4,7 @@ const path = require('path');
 const webpack = require('webpack');
 const clone = require('lodash.clonedeep');
 const { userPrototypePath, prototypeBuildPath, srcPath } = require('kyt-utils/paths')();
+const postcssLoader = require('../utils/getPostcssLoader');
 
 const cssStyleLoaders = [
   'style-loader',
@@ -11,7 +12,7 @@ const cssStyleLoaders = [
     loader: 'css-loader',
     options: { modules: true, sourceMap: true, localIdentName: '[name]-[local]--[hash:base64:5]' },
   },
-  'postcss-loader',
+  postcssLoader,
 ];
 
 module.exports = options => {


### PR DESCRIPTION
Updates to the dev and prod webpack configs changed the way the postcss-loader is configured in ways that were not mirrored in webpack.proto.js. As a result, `yarn run proto` fails because it can't find a postcss.config.js file. This change fixes that issue (though there appear to be some other issues issues that break `yarn run proto`, as seen in issue #567, which I'm still running down).