### PR TITLE
STRIK-1008: fully remove ES6 from client.js

### DIFF
--- a/packages/kyt-runtime/client.js
+++ b/packages/kyt-runtime/client.js
@@ -1,3 +1,4 @@
-var { preloadReady } = require('./lib/loadable');
+// this file doesn't get transpiled. Please avoid ES6 syntax.
+var preloadReady = require('./lib/loadable').preloadReady; // eslint-disable-line
 
 exports.preloadDynamicImports = preloadReady;


### PR DESCRIPTION
https://github.com/nytimes/kyt/pull/615 left behind the destructuring of the module that makes IE keep tripping.
