### PR TITLE
Update eslint-react-plugin to v7.17

### DIFF
--- a/packages/eslint-config-kyt/package.json
+++ b/packages/eslint-config-kyt/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-kyt": "pre",
     "eslint-plugin-prettier": "3.1.0",
-    "eslint-plugin-react": "7.13.0",
+    "eslint-plugin-react": "7.17.0",
     "eslint-plugin-react-hooks": "1.6.0",
     "prettier": "1.17.1"
   },

--- a/packages/kyt-core/package.json
+++ b/packages/kyt-core/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-kyt": "1.0.0-alpha.0",
     "eslint-plugin-prettier": "3.1.0",
-    "eslint-plugin-react": "7.13.0",
+    "eslint-plugin-react": "7.17.0",
     "eslint-plugin-react-hooks": "1.6.0",
     "express": "4.17.1",
     "file-loader": "3.0.1",


### PR DESCRIPTION
This PR bumps eslint-react-plugin to v7.17.0, which would allow for the use of some newer lint rules, such as [react/jsx-no-useless-fragment](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md).