### PR TITLE
add modulesDir flag to kyt config

### DIFF
--- a/packages/kyt-core/config/webpack.dev.server.js
+++ b/packages/kyt-core/config/webpack.dev.server.js
@@ -17,7 +17,7 @@ module.exports = options => ({
     __filename: false,
   },
 
-  externals: nodeExternals(),
+  externals: [nodeExternals({ modulesDir: options.modulesDir })],
 
   entry: {
     main: [getPolyfill(options.type), `${serverSrcPath}/index.js`].filter(Boolean),

--- a/packages/kyt-core/config/webpack.prod.server.js
+++ b/packages/kyt-core/config/webpack.prod.server.js
@@ -17,7 +17,7 @@ module.exports = options => ({
     __filename: false,
   },
 
-  externals: nodeExternals(),
+  externals: [nodeExternals({ modulesDir: options.modulesDir })],
 
   entry: {
     main: [getPolyfill(options.type), `${serverSrcPath}/index.js`].filter(Boolean),

--- a/packages/kyt-core/utils/buildConfigs.js
+++ b/packages/kyt-core/utils/buildConfigs.js
@@ -17,7 +17,7 @@ const prodClientConfig = require('../config/webpack.prod.client');
 const prodServerConfig = require('../config/webpack.prod.server');
 
 module.exports = (config, environment = 'development') => {
-  const { clientURL, serverURL, reactHotLoader } = config;
+  const { clientURL, serverURL, reactHotLoader, modulesDir } = config;
 
   let clientConfig = devClientConfig;
   let serverConfig = devServerConfig;
@@ -42,7 +42,7 @@ module.exports = (config, environment = 'development') => {
     });
   }
 
-  const serverOptions = merge(clientOptions, { type: 'server' });
+  const serverOptions = merge(clientOptions, { type: 'server', modulesDir });
 
   const hasBabelrc = findBabelConfigSync(userRootPath);
   if (!hasBabelrc || !hasBabelrc.config) {


### PR DESCRIPTION
To support monorepos that hoist dependencies to the root of the project, we need to add a `modulesDir` option that can be passed to the function returned by `webpack-node-externals`. Currently, it only searches `node_modules` in the directory containing `kyt.config.js` - none of the hoisted dependencies will be there, they are in the root!

I think adding this option is the best route - otherwise, you have to mutate the supplied `kytConfig` in `kyt.config.js`, override `externals` for the server, and add a new function that requires a lot of boilerplate from `webpack-node-externals`.