### PR TITLE
add watchDirs to kyt config

### DIFF
--- a/packages/kyt-core/cli/actions/dev.js
+++ b/packages/kyt-core/cli/actions/dev.js
@@ -25,7 +25,7 @@ module.exports = (config, flags) => {
   let clientCompiler;
   let serverCompiler;
   const { clientConfig, serverConfig } = buildConfigs(config);
-  const { clientURL, serverURL, reactHotLoader, hasServer, hasClient } = config;
+  const { clientURL, serverURL, reactHotLoader, hasServer, hasClient, watchDirs } = config;
 
   const afterClientCompile = once(() => {
     if (reactHotLoader) logger.task('Setup React Hot Loader');
@@ -95,7 +95,11 @@ module.exports = (config, flags) => {
   // Compile Server Webpack Config
   if (hasServer) {
     // Watch the server files and recompile and restart on changes.
-    const watcher = chokidar.watch([serverSrcPath]);
+    let serverWatchDirs = [serverSrcPath];
+    if (watchDirs) {
+      serverWatchDirs = serverWatchDirs.concat(watchDirs);
+    }
+    const watcher = chokidar.watch(serverWatchDirs);
     watcher.on('ready', () => {
       watcher
         .on('add', compileServer)


### PR DESCRIPTION
`kyt dev`: for projects with a server, the only directory that is watched by `chokidar` is `src/server`. This is inadequate if the project relies on modules with alias'd paths outside of `src/server`.

Example:
`projects/amp/src/server/index.js` relies on
`projects/components/src/Span/index.js`

`watchDirs` is an optional flag that can be added so that `chokidar` reacts to the alias'd files changing and restarts the server.