### PR TITLE
fix: remove eval from cheap-module-source-map

### DIFF
--- a/packages/kyt-core/src/config/webpack.dev.client.js
+++ b/packages/kyt-core/src/config/webpack.dev.client.js
@@ -18,7 +18,7 @@ module.exports = options => {
 
     target: 'web',
 
-    devtool: 'eval-cheap-module-source-map',
+    devtool: 'cheap-module-source-map',
 
     entry: {
       main,


### PR DESCRIPTION
Fixes source maps.

- Jira ticket: https://jira.nyt.net/browse/WF-1523
- Related: https://github.com/nytm/wf-project-vi/pull/11469/files