### PR TITLE
fix: include code-split node_modules in loadable manifest

### DIFF
--- a/packages/kyt-runtime/src/loadable-plugin.js
+++ b/packages/kyt-runtime/src/loadable-plugin.js
@@ -5,8 +5,6 @@ const fs = require('fs');
 const path = require('path');
 const url = require('url');
 
-/* eslint-disable no-continue,no-restricted-syntax */
-
 function ignoreModule(name, vendorTest, ignoreModuleTest) {
   if (name && ignoreModuleTest) {
     if (typeof ignoreModuleTest === 'function') {
@@ -45,11 +43,13 @@ function buildManifest(compiler, compilation, opts) {
         return;
       }
 
+      // eslint-disable-next-line no-restricted-syntax
       for (const module of chunk.modulesIterable) {
         const { id } = module;
         const name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
 
         if (ignoreModule(name, vendorTest, ignoreModuleTest)) {
+          // eslint-disable-next-line no-continue
           continue;
         }
 


### PR DESCRIPTION
When generating the react-loadable manifest file, don't automatically exclude all modules with `node_modules` in their path.

In production builds, look for a vendor bundle / chunkGroup.

In all envs, default to configurable test function, if present, that is reachable from `kyt.config.js`.

```js
if (options.environment === 'development' && options.type === 'client') {
  const loadable = appConfig.plugins.find(p => p.constructor.name === 'LoadablePlugin');
  loadable.setIgnoreModuleTest(vendorTest);
}
```