### PR TITLE
fix: set url when instantiating jsdom

### DIFF
--- a/packages/jest-preset-kyt-enzyme/setup.js
+++ b/packages/jest-preset-kyt-enzyme/setup.js
@@ -4,7 +4,7 @@ const Adapter = require('enzyme-adapter-react-16');
 
 configure({ adapter: new Adapter() });
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
 const { window } = jsdom;
 
 function copyProps(src, target) {


### PR DESCRIPTION
when running in `testEnvironment: "node"`, this code fixes:
```
SecurityError: localStorage is not available for opaque origins
```