### PR TITLE
feat(jest-preset-kyt-enzyme): match and collect coverage from .ts/.tsx files

### DIFF
--- a/packages/jest-preset-kyt-enzyme/jest-preset.js
+++ b/packages/jest-preset-kyt-enzyme/jest-preset.js
@@ -9,9 +9,9 @@ const jestConfig = {
   setupFilesAfterEnv: [require.resolve('./setup')],
   // if projects spread this value, the import can be lost if it is not absolute
   snapshotSerializers: [require.resolve('enzyme-to-json/serializer')],
-  testMatch: ['**/*.test.js'],
+  testMatch: ['**/*.test.[jt]s?(x)'],
   testEnvironment: require.resolve('jest-environment-jsdom'),
-  collectCoverageFrom: ['**/*.js'],
+  collectCoverageFrom: ['**/*.[jt]s?(x)'],
   coverageDirectory: '<rootDir>/coverage',
   errorOnDeprecated: true,
   cacheDirectory: '<rootDir>/.caches/jest',


### PR DESCRIPTION
This PR updates `jest-preset-kyt-enzyme`'s `testMatch` and `collectCoverageFrom` config options to match the following file extensions:
- `.js`
- `.jsx`
- `.ts`
- `.tsx`

This means we now allow `.ts` / `.tsx` test files (as is [Jest's default](https://jestjs.io/docs/configuration#testmatch-arraystring)) and will collect coverage from `.ts` / `.tsx` source files when asked.

As is the case with Jest out of the box, end users will have to [configure TypeScript transpilation](https://jestjs.io/docs/getting-started#using-typescript) themselves.