### PR TITLE
fix(jest-preset-kyt-enzyme): update moduleFileExtensions too

### DIFF
--- a/packages/jest-preset-kyt-enzyme/jest-preset.js
+++ b/packages/jest-preset-kyt-enzyme/jest-preset.js
@@ -1,6 +1,6 @@
 const jestConfig = {
   verbose: true,
-  moduleFileExtensions: ['js', 'jsx', 'json'],
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
   moduleNameMapper: {
     '^[./a-zA-Z0-9!&$_-]+\\.(css|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|ico|md)$':
       require.resolve('./stub'),


### PR DESCRIPTION
I missed `moduleFileExtensions` in #825, so here's that, too. Now we support modules with `.ts` / `.tsx` extensions, too.

The [Jest default](https://jestjs.io/docs/configuration#modulefileextensions-arraystring) includes `.node`, too, which I've omitted because it's just way too weird IMO. I also don't think we use that anywhere.