### PR TITLE
fix(babel-preset-kyt-core): set `loose: true` in @babel/preset-env options

### DIFF
--- a/packages/babel-preset-kyt-core/src/index.js
+++ b/packages/babel-preset-kyt-core/src/index.js
@@ -17,6 +17,12 @@ module.exports = function getPresetCore(context, opts) {
     targets: {
       browsers: ['>1%', 'last 4 versions', 'not ie < 11'],
     },
+    /**
+     * Ensure that certain plugins added by `@babel/preset-env` match the `loose: true`
+     * configuration option we set below for both `@babel/plugin-proposal-class-properties`
+     * and `@babel/plugin-proposal-private-methods`
+     */
+    loose: true,
   };
 
   const serverEnvOptions = {
@@ -30,6 +36,12 @@ module.exports = function getPresetCore(context, opts) {
     targets: {
       node: 'current',
     },
+    /**
+     * Ensure that certain plugins added by `@babel/preset-env` match the `loose: true`
+     * configuration option we set below for both `@babel/plugin-proposal-class-properties`
+     * and `@babel/plugin-proposal-private-methods`
+     */
+    loose: true,
   };
 
   // Derive the babel-preset-env options based on the type of environment


### PR DESCRIPTION
## Description
This PR sets `@babel/preset-env`'s `loose` option to `true` ([docs](https://babeljs.io/docs/en/babel-preset-env.html#loose)) in both the `clientEnvOptions` and `serverEnvOptions`.

Doing so ensures that certain other plugins automatically added by `@babel/preset-env` match the `loose: true` options we set for both `@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-private-methods`. This avoids a configuration mismatch we've been seeing logged out when building Hybrid's client scripts:

<details><summary>Console message from Babel when running <code>yarn workspace hybrid webpack</code></summary>

```
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
```
</details>

For more details and the prior discussion regarding this issue, please see [this Slack thread](https://nytimes.slack.com/archives/CJKV2D8GK/p1631803775073200). (Thanks @ilyaGurevich!)