### PR TITLE
fix: silence "loose" warnings from babel plugin(s)

### DIFF
--- a/packages/babel-preset-kyt-core/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-preset-kyt-core/src/__tests__/__snapshots__/index.test.js.snap
@@ -21,6 +21,12 @@ Object {
         "loose": true,
       },
     ],
+    Array [
+      "@babel/plugin-proposal-private-property-in-object",
+      Object {
+        "loose": true,
+      },
+    ],
     "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-syntax-dynamic-import",
   ],

--- a/packages/babel-preset-kyt-core/src/__tests__/index.test.js
+++ b/packages/babel-preset-kyt-core/src/__tests__/index.test.js
@@ -42,19 +42,19 @@ describe('babel-preset-kyt-core', () => {
   it('should support an `includeRuntime` option', () => {
     const config = presetKytCore({}, { includeRuntime: true });
 
-    expect(config.plugins[4]).toEqual('@babel/plugin-transform-runtime');
+    expect(config.plugins[5]).toEqual('@babel/plugin-transform-runtime');
   });
 
   it('should include a dynamic import plugin', () => {
     const config = presetKytCore();
 
-    expect(config.plugins[4]).toEqual('@babel/plugin-syntax-dynamic-import');
+    expect(config.plugins[5]).toEqual('@babel/plugin-syntax-dynamic-import');
   });
 
   it('should include a import node plugin when KYT_ENV_TYPE=test', () => {
     process.env.KYT_ENV_TYPE = 'test';
     const config = presetKytCore();
 
-    expect(config.plugins[5]).toEqual('babel-plugin-dynamic-import-node');
+    expect(config.plugins[6]).toEqual('babel-plugin-dynamic-import-node');
   });
 });

--- a/packages/babel-preset-kyt-core/src/index.js
+++ b/packages/babel-preset-kyt-core/src/index.js
@@ -63,6 +63,7 @@ module.exports = function getPresetCore(context, opts) {
       ['@babel/plugin-proposal-class-properties', { loose: true }],
       // needed to suppress warnings about mismatched "loose" values across plugins
       ['@babel/plugin-proposal-private-methods', { loose: true }],
+      ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
       '@babel/plugin-proposal-optional-chaining',
       // provide the ability to opt into babel-plugin-transform-runtime inclusion
       opts.includeRuntime === true && '@babel/plugin-transform-runtime',


### PR DESCRIPTION
It was brought to our attention by @ilyaGurevich (Thanks Ilya!) that
various warnings about inconsistent usage of the `loose` option for a
few babel plugins.

This commit sets the `loose` option explicitly for
`@babel/plugin-proposal-private-property-in-object` to silence the
warning, which @kohlmannj found was added to `@babel/preset-env` in
babel/babel#13176.

This should resolve the warnings folks had been seeing.

Closes #906
Closes #905