### PR TITLE
ci: switch to github actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: yarn
     - run: yarn exec lerna run prepare
     - run: yarn lint:ci
     - run: yarn test:ci

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  kyt-tests:
+    name: "Test with Node LTS Versions"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn exec lerna run prepare
+    - run: yarn lint:ci
+    - run: yarn test:ci
+    - run: yarn e2e

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,12 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   kyt-tests:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,6 @@
 name: Continuous Integration
 
-on:
-  push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
+on: [push, pull_request]
 
 jobs:
   kyt-tests:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   kyt-tests:
-    name: "Test with Node LTS Versions"
+    name: "Lint, Test with Node"
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
So we now have support for GitHub Actions in this repository and we would like to switch to that as our CI/CD solution.

Unfortunately, at least one of our tools (`commitlint`) doesn't support Node <= 12.x, so testing for 10.x isn't supported here.

For what it's worth, we haven't been testing 10.x for a long while now. I need to check our history to see if we dropped support for 10.x at some point outside of this pull request.

Commits cherry-picked from PR #699 (thanks @gabrielfalcao!)

Closes #908 