### PR TITLE
build(node): upgrade to lts/gallium

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-14.15.0
+lts/gallium


### PR DESCRIPTION
This primarily just changes the version of node defined in our `nvm`
configuration such that M1 architecture chips can build `kyt` as well.

Additionally, this adds checks in our Node version matrix for 16.x.