### PR TITLE
docs: note on branching off main when publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,10 @@ This can be accomplished with the following command:
 $ GH_TOKEN=$GITHUB_TOKEN npm run publish
 ```
 
+`npm run publish` will push a new commit to the current branch, so _it is
+recommended to branch off of `main` prior to doing a new release_ to avoid
+pushing directly to `main`.
+
 For more information on using `lerna` to publish, see [the `lerna publish`
 documentation](https://github.com/lerna/lerna/tree/main/commands/publish#readme).
 


### PR DESCRIPTION
This commit adds a note to the CONTRIBUTING documentation to let folks
know that running `npm run publish` will create a new commit on the
current branch and push it up.

This might not be expected so felt that it would be good to explicitly
call out.