### PR TITLE
feat(babel-preset-kyt-react): add babel-plugin-pure-static-props when productionTransforms is true

### DIFF
--- a/packages/babel-preset-kyt-react/package.json
+++ b/packages/babel-preset-kyt-react/package.json
@@ -17,6 +17,7 @@
     "@babel/plugin-transform-react-inline-elements": "7.16.7",
     "@babel/preset-react": "7.14.5",
     "babel-plugin-add-react-displayname": "0.0.5",
+    "babel-plugin-pure-static-props": "0.2.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-preset-kyt-core": "2.0.0"
   },

--- a/packages/babel-preset-kyt-react/src/index.js
+++ b/packages/babel-preset-kyt-react/src/index.js
@@ -19,11 +19,10 @@ module.exports = function getPresetReact(context, opts) {
   if (useProductionTransforms === true) {
     productionTransforms.push(reactTransformConstant);
     productionTransforms.push(reactTransformInline);
-    productionTransforms.push(pureStaticProps);
   }
 
   return {
-    plugins: [addReactDisplayName],
+    plugins: [addReactDisplayName, pureStaticProps],
     env: {
       development: {
         presets: [

--- a/packages/babel-preset-kyt-react/src/index.js
+++ b/packages/babel-preset-kyt-react/src/index.js
@@ -1,5 +1,6 @@
 const babelPresetReact = require('@babel/preset-react');
 const addReactDisplayName = require('babel-plugin-add-react-displayname');
+const pureStaticProps = require('babel-plugin-pure-static-props');
 const reactRemovePropTypes = require('babel-plugin-transform-react-remove-prop-types');
 const reactTransformConstant = require('@babel/plugin-transform-react-constant-elements');
 const reactTransformInline = require('@babel/plugin-transform-react-inline-elements');
@@ -18,6 +19,7 @@ module.exports = function getPresetReact(context, opts) {
   if (useProductionTransforms === true) {
     productionTransforms.push(reactTransformConstant);
     productionTransforms.push(reactTransformInline);
+    productionTransforms.push(pureStaticProps);
   }
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,13 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
+  integrity sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-annotate-as-pure@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz#7bf478ec3b71726d56a8ca5775b046fc29879e61"
@@ -290,6 +297,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
+"@babel/helper-plugin-utils@^7.18.6":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz#4796bb14961521f0f8715990bee2fb6e51ce21bf"
+  integrity sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==
+
 "@babel/helper-remap-async-to-generator@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz#51439c913612958f54a987a4ffc9ee587a2045d6"
@@ -363,6 +375,11 @@
   dependencies:
     "@babel/types" "^7.15.4"
 
+"@babel/helper-string-parser@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
+  integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
+
 "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
   version "7.14.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
@@ -377,6 +394,11 @@
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
+"@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -634,6 +656,13 @@
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-jsx@^7.12.13":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
+  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-syntax-jsx@^7.14.5":
   version "7.14.5"
@@ -1201,6 +1230,15 @@
   integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.6":
+  version "7.19.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.3.tgz#fc420e6bbe54880bce6779ffaf315f5e43ec9624"
+  integrity sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -3557,6 +3595,14 @@ babel-plugin-polyfill-regenerator@^0.2.2:
   integrity sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.2"
+
+babel-plugin-pure-static-props@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-pure-static-props/-/babel-plugin-pure-static-props-0.2.0.tgz#b4ca0eac8f0394809357d60dc0df1f01f52198b0"
+  integrity sha512-2jOy4pyd2NJq2o9VSFQeOM6XRsfB3yfKha1PxvbwOOthYAFdTOXVkAXPxsU0e4PTHoqeZAafMVVuVfmICtLiQg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
 
 babel-plugin-replace-ts-export-assignment@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
relates to [DSYS-10](https://jira.nyt.net/browse/DSYS-10)

## Description

This PR adds [`babel-plugin-pure-static-props`](https://github.com/mbrowne/babel-plugin-pure-static-props) to `babel-preset-kyt-react`'s set of production transforms (enabled when the preset's `productionTransforms` option is set to `true`).

## Motivation / Background

Static properties on [React] components break tree-shaking: https://github.com/styled-components/babel-plugin-styled-components/issues/245#issuecomment-525844957

This same commenter created `babel-plugin-pure-static-props` to address this. From its [README](https://github.com/mbrowne/babel-plugin-pure-static-props):  

> This plugin replaces static property assignments on React components (e.g. `MyComponent.defaultProps = {...}`) with `Object.assign()` statements annotated with `/*#__PURE__*/` comments so that tree-shaking will work correctly.

This is an especially important optimization for `babel-preset-kyt-react` because we add the static property `displayName` to every React component via [`babel-plugin-add-react-displayname`](https://babeljs.io/docs/en/babel-plugin-transform-react-display-name). That is, this plugin is always enabled. (For that reason, we may consider always enabling `babel-plugin-pure-static-props` as well.)