### PR TITLE
fix: prettier + stylelint clashing

### DIFF
--- a/packages/jest-preset-kyt-styled/package.json
+++ b/packages/jest-preset-kyt-styled/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "create-jest-runner": "0.7.0",
     "stylelint": "13.13.1",
+    "stylelint-config-prettier": "9.0.3",
     "stylelint-config-standard": "22.0.0",
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.10.0"

--- a/packages/jest-preset-kyt-styled/src/.stylelintrc.js
+++ b/packages/jest-preset-kyt-styled/src/.stylelintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   processors: ['stylelint-processor-styled-components'],
-  extends: ['stylelint-config-standard', 'stylelint-config-styled-components'],
+  extends: ['stylelint-config-standard', 'stylelint-config-styled-components', 'stylelint-config-prettier'],
   rules: {
     'declaration-colon-newline-after': null,
     'declaration-no-important': true,


### PR DESCRIPTION
Stylelint and prettier want different things. This adds the prettier config to the jest stylelint so that they can work together.