### PR TITLE
fix(babel-preset-kyt): ensure that @babel/preset-typescript is the last preset in the array

### DIFF
--- a/packages/babel-preset-kyt/src/__tests__/index.test.js
+++ b/packages/babel-preset-kyt/src/__tests__/index.test.js
@@ -1,0 +1,18 @@
+const presetTypescript = require('@babel/preset-typescript');
+const presetKyt = require('..');
+
+jest.mock('babel-preset-kyt-react', () => 'babel-preset-kyt-react');
+jest.mock('@babel/preset-typescript', () => '@babel/preset-typescript');
+
+describe('babel-preset-kyt', () => {
+  /**
+   * Note that unlike plugins, the presets are applied in an order of last to first
+   * (https://babeljs.io/docs/en/presets/#preset-ordering), so please make sure
+   * `@babel/preset-typescript` is the last preset in this array.
+   */
+  it('includes @babel/preset-typescript as the last preset in the array', () => {
+    const config = presetKyt({});
+
+    expect(config.presets[config.presets.length - 1]).toBe(presetTypescript);
+  });
+});

--- a/packages/babel-preset-kyt/src/__tests__/index.test.js
+++ b/packages/babel-preset-kyt/src/__tests__/index.test.js
@@ -1,8 +1,8 @@
 const presetTypescript = require('@babel/preset-typescript');
 const presetKyt = require('..');
 
-jest.mock('babel-preset-kyt-react', () => 'babel-preset-kyt-react');
 jest.mock('@babel/preset-typescript', () => '@babel/preset-typescript');
+jest.mock('babel-preset-kyt-react', () => 'babel-preset-kyt-react');
 
 describe('babel-preset-kyt', () => {
   /**

--- a/packages/babel-preset-kyt/src/index.js
+++ b/packages/babel-preset-kyt/src/index.js
@@ -4,7 +4,12 @@ const babelPluginReplaceTsExportAssignment = require('babel-plugin-replace-ts-ex
 
 module.exports = function getPreset(context, opts) {
   return {
-    presets: [babelPresetTypescript, [babelPresetKytReact, opts || {}]],
+    /**
+     * Note that unlike plugins, the presets are applied in an order of last to first
+     * (https://babeljs.io/docs/en/presets/#preset-ordering), so please make sure
+     * `@babel/preset-typescript` is the last preset in this array.
+     */
+    presets: [[babelPresetKytReact, opts || {}], babelPresetTypescript],
     plugins: [babelPluginReplaceTsExportAssignment],
   };
 };


### PR DESCRIPTION
relates to #1135
blocks nytimes/news#5565

## Description

This PR updates `babel-preset-kyt` to ensure that `@babel/preset-typescript` appears last in the `presets` array, and thus, is applied _first_ ([docs](https://babeljs.io/docs/presets/#preset-ordering)).

This fixes an issue in which Babel could fail to transpile certain TypeScript syntax, such as the [TypeScript “constructor shorthand” syntax](https://dev.to/satansdeer/typescript-constructor-shorthand-3ibd), when using `babel-preset-kyt` v1.1.20.

## How to Review

1. Check out [nytimes/babel-hell-2k23](https://github.com/nytimes/babel-hell-2k23)
2. Install or `yarn link` a pre-release version of `babel-preset-kyt` created from the contents of this PR
3. Verify that running `yarn test` exits without an error ("The resulting code appears to be OK:")
